### PR TITLE
Filter date() respects active timezone

### DIFF
--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -189,6 +189,7 @@ class Filters
 
 		} elseif (!$time instanceof \DateTime && !$time instanceof \DateTimeInterface) {
 			$time = new \DateTime((is_numeric($time) ? '@' : '') . $time);
+			$time->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
 		}
 		return strpos($format, '%') === FALSE
 			? $time->format($format) // formats using date()

--- a/tests/Latte/Filters.date().phpt
+++ b/tests/Latte/Filters.date().phpt
@@ -36,3 +36,7 @@ Assert::same( "1212-09-26", Filters::date(new DateTime('1212-09-26'), 'Y-m-d') )
 
 
 Assert::same( "30:10:10", Filters::date(new DateInterval('PT30H10M10S'), '%H:%I:%S') );
+
+
+date_default_timezone_set('America/Los_Angeles');
+Assert::same( "07:09", Filters::date(1408284571, 'H:i') );


### PR DESCRIPTION
Fixes bug introduced in Latte 2.2. PR is based on master, but the fix should be cherry-picked for 2.2 as well.

See http://forum.nette.org/en/20332-date-helper-returns-wrong-time-if-date-function-is-used
