### PR TITLE
Engine: inlined constant values to avoid loading Compiler in runtime

### DIFF
--- a/src/Latte/Compiler.php
+++ b/src/Latte/Compiler.php
@@ -52,14 +52,14 @@ class Compiler extends Object
 	private $lastAttrValue;
 
 	/** Context-aware escaping content types */
-	const CONTENT_HTML = 'html',
-		CONTENT_XHTML = 'xhtml',
-		CONTENT_XML = 'xml',
-		CONTENT_JS = 'js',
-		CONTENT_CSS = 'css',
-		CONTENT_URL = 'url',
-		CONTENT_ICAL = 'ical',
-		CONTENT_TEXT = 'text';
+	const CONTENT_HTML = Engine::CONTENT_HTML,
+		CONTENT_XHTML = Engine::CONTENT_XHTML,
+		CONTENT_XML = Engine::CONTENT_XML,
+		CONTENT_JS = Engine::CONTENT_JS,
+		CONTENT_CSS = Engine::CONTENT_CSS,
+		CONTENT_URL = Engine::CONTENT_URL,
+		CONTENT_ICAL = Engine::CONTENT_ICAL,
+		CONTENT_TEXT = Engine::CONTENT_TEXT;
 
 	/** @internal Context-aware escaping HTML contexts */
 	const CONTEXT_COMMENT = 'comment',

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -16,13 +16,14 @@ namespace Latte;
 class Engine extends Object
 {
 	/** Content types */
-	const CONTENT_HTML = Compiler::CONTENT_HTML,
-		CONTENT_XHTML = Compiler::CONTENT_XHTML,
-		CONTENT_XML = Compiler::CONTENT_XML,
-		CONTENT_JS = Compiler::CONTENT_JS,
-		CONTENT_CSS = Compiler::CONTENT_CSS,
-		CONTENT_ICAL = Compiler::CONTENT_ICAL,
-		CONTENT_TEXT = Compiler::CONTENT_TEXT;
+	const CONTENT_HTML = 'html',
+		CONTENT_XHTML = 'xhtml',
+		CONTENT_XML = 'xml',
+		CONTENT_JS = 'js',
+		CONTENT_CSS = 'css',
+		CONTENT_URL = 'url',
+		CONTENT_ICAL = 'ical',
+		CONTENT_TEXT = 'text';
 
 	/** @var callable[] */
 	public $onCompile = array();


### PR DESCRIPTION
Also the Compiler also has `CONTENT_URL`. Should we add it? Should the `Compiler` be updated to load the constant values from the `Engine`?