### PR TITLE
BlockMacros: runtime helpers moved to BlockMacrosRuntime

### DIFF
--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -123,7 +123,7 @@ class BlockMacros extends MacroSet
 		if (isset($this->namedBlocks[$destination]) && !$parent) {
 			$cmd = "call_user_func(reset(\$_b->blocks[$name]), \$_b, %node.array? + get_defined_vars())";
 		} else {
-			$cmd = 'Latte\Macros\BlockMacros::callBlock' . ($parent ? 'Parent' : '') . "(\$_b, $name, %node.array? + " . ($parent ? 'get_defined_vars' : '$template->getParameters') . '())';
+			$cmd = 'Latte\Macros\BlockMacrosRuntime::callBlock' . ($parent ? 'Parent' : '') . "(\$_b, $name, %node.array? + " . ($parent ? 'get_defined_vars' : '$template->getParameters') . '())';
 		}
 
 		if ($node->modifiers) {
@@ -315,37 +315,6 @@ class BlockMacros extends MacroSet
 		}
 		return ($node->name === 'elseifset' ? '} else' : '')
 			. 'if (isset(' . implode(', ', $list) . ')) {';
-	}
-
-
-	/********************* run-time helpers ****************d*g**/
-
-
-	/**
-	 * Calls block.
-	 * @return void
-	 */
-	public static function callBlock(\stdClass $context, $name, array $params)
-	{
-		if (empty($context->blocks[$name])) {
-			throw new RuntimeException("Cannot include undefined block '$name'.");
-		}
-		$block = reset($context->blocks[$name]);
-		$block($context, $params);
-	}
-
-
-	/**
-	 * Calls parent block.
-	 * @return void
-	 */
-	public static function callBlockParent(\stdClass $context, $name, array $params)
-	{
-		if (empty($context->blocks[$name]) || ($block = next($context->blocks[$name])) === FALSE) {
-			throw new RuntimeException("Cannot include undefined parent block '$name'.");
-		}
-		$block($context, $params);
-		prev($context->blocks[$name]);
 	}
 
 }

--- a/src/Latte/Macros/BlockMacrosRuntime.php
+++ b/src/Latte/Macros/BlockMacrosRuntime.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Latte\Macros;
+
+use Latte,
+	Latte\RuntimeException;
+
+
+/**
+ * Runtime helpers for block macros.
+ *
+ * @author     David Grudl
+ */
+class BlockMacrosRuntime extends Latte\Object
+{
+
+	/**
+	 * Calls block.
+	 * @return void
+	 */
+	public static function callBlock(\stdClass $context, $name, array $params)
+	{
+		if (empty($context->blocks[$name])) {
+			throw new RuntimeException("Cannot include undefined block '$name'.");
+		}
+		$block = reset($context->blocks[$name]);
+		$block($context, $params);
+	}
+
+
+	/**
+	 * Calls parent block.
+	 * @return void
+	 */
+	public static function callBlockParent(\stdClass $context, $name, array $params)
+	{
+		if (empty($context->blocks[$name]) || ($block = next($context->blocks[$name])) === FALSE) {
+			throw new RuntimeException("Cannot include undefined parent block '$name'.");
+		}
+		$block($context, $params);
+		prev($context->blocks[$name]);
+	}
+
+}

--- a/src/latte.php
+++ b/src/latte.php
@@ -14,6 +14,7 @@ spl_autoload_register(function($className) {
 		'Latte\\MacroNode' => 'MacroNode.php',
 		'Latte\\MacroTokens' => 'MacroTokens.php',
 		'Latte\\Macros\\BlockMacros' => 'Macros/BlockMacros.php',
+		'Latte\\Macros\\BlockMacrosRuntime' => 'Macros/BlockMacrosRuntime.php',
 		'Latte\\Macros\\CoreMacros' => 'Macros/CoreMacros.php',
 		'Latte\\Macros\\MacroSet' => 'Macros/MacroSet.php',
 		'Latte\\Object' => 'Object.php',

--- a/tests/Latte/expected/macros.dynamicblock.phtml
+++ b/tests/Latte/expected/macros.dynamicblock.phtml
@@ -43,11 +43,11 @@ if (!function_exists($_b->blocks[$name]['%[a-z0-9]+%'] = '_%[a-z0-9]+%__name')) 
 
 <?php }} call_user_func(reset($_b->blocks[$name]), $_b, get_defined_vars()) ;$iterations++; } array_pop($_l->its); $iterator = end($_l->its) ?>
 
-<?php Latte\Macros\BlockMacros::callBlock($_b, 'dynamic', array('var' => 20) + $template->getParameters()) ?>
+<?php Latte\Macros\BlockMacrosRuntime::callBlock($_b, 'dynamic', array('var' => 20) + $template->getParameters()) ?>
 
 <?php call_user_func(reset($_b->blocks['static']), $_b, array('var' => 30) + get_defined_vars()) ?>
 
-<?php Latte\Macros\BlockMacros::callBlock($_b, $name, array('var' => 40) + $template->getParameters()) ?>
+<?php Latte\Macros\BlockMacrosRuntime::callBlock($_b, $name, array('var' => 40) + $template->getParameters()) ?>
 
 <?php
 

--- a/tests/Latte/expected/macros.includeblock.phtml
+++ b/tests/Latte/expected/macros.includeblock.phtml
@@ -12,5 +12,5 @@ list($_b, $_g, $_l) = $template->initialize('%[a-z0-9]+%', 'html')
 <?php ob_start(); $_b->templates['%[a-z0-9]+%']->renderChildTemplate('includeblock.inc.latte', get_defined_vars()); echo rtrim(ob_get_clean()) ?>
 
 
-<?php Latte\Macros\BlockMacros::callBlock($_b, 'test', $template->getParameters()) ;
+<?php Latte\Macros\BlockMacrosRuntime::callBlock($_b, 'test', $template->getParameters()) ;
 %A%

--- a/tests/Latte/expected/macros.inheritance.child1.child.phtml
+++ b/tests/Latte/expected/macros.inheritance.child1.child.phtml
@@ -9,7 +9,7 @@ list($_b, $_g, $_l) = $template->initialize('%[a-z0-9]+%', 'html')
 // block title
 //
 if (!function_exists($_b->blocks['title'][] = '_%[a-z0-9]+%_title')) { function _%[a-z0-9]+%_title($_b, $_args) { foreach ($_args as $__k => $__v) $$__k = $__v
-?>Homepage | <?php Latte\Macros\BlockMacros::callBlockParent($_b, 'title', get_defined_vars()) ;Latte\Macros\BlockMacros::callBlockParent($_b, 'title', get_defined_vars()) ;
+?>Homepage | <?php Latte\Macros\BlockMacrosRuntime::callBlockParent($_b, 'title', get_defined_vars()) ;Latte\Macros\BlockMacrosRuntime::callBlockParent($_b, 'title', get_defined_vars()) ;
 }}
 
 //

--- a/tests/Latte/expected/macros.inheritance.child1.parent.phtml
+++ b/tests/Latte/expected/macros.inheritance.child1.parent.phtml
@@ -51,7 +51,7 @@ call_user_func(reset($_b->blocks['title']), $_b, get_defined_vars())  ?></title>
 	</div>
 
 	<div id="content">
-<?php Latte\Macros\BlockMacros::callBlock($_b, 'content', $template->getParameters()) ?>
+<?php Latte\Macros\BlockMacrosRuntime::callBlock($_b, 'content', $template->getParameters()) ?>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
Splitting prevents loading `MacroSet.php` and `IMacro.php` files in runtime. Were the runtime helpers considered internal or should I keep them in `BlockMacros` for compatibility?