### PR TITLE
Inline filters

### DIFF
--- a/src/Latte/Parser.php
+++ b/src/Latte/Parser.php
@@ -391,7 +391,7 @@ class Parser
 				(?P<name>\?|/?[a-z]\w*+(?:[.:]\w+)*+(?!::|\(|\\\\))|   ## ?, name, /name, but not function( or class:: or namespace\
 				(?P<noescape>!?)(?P<shortname>/?[=\~#%^&_]?)      ## !expression, !=expression, ...
 			)(?P<args>(?:' . self::RE_STRING . '|[^\'"])*?)
-			(?P<modifiers>(?<!\|)\|[a-z](?:' . self::RE_STRING . '|[^\'"/]|/(?=.))*+)?
+			(?P<modifiers>(?<!\|)\|[a-z](?P<modArgs>(?:' . self::RE_STRING . '|(?:\((?P>modArgs)\))|[^\'"/()]|/(?=.))*+))?
 			(?P<empty>/?\z)
 		()\z~isx', $tag, $match)) {
 			if (preg_last_error()) {

--- a/src/Latte/PhpWriter.php
+++ b/src/Latte/PhpWriter.php
@@ -159,6 +159,7 @@ class PhpWriter
 		$tokens = $tokens === NULL ? $this->tokens : $tokens;
 		$tokens = $this->removeCommentsFilter($tokens);
 		$tokens = $this->shortTernaryFilter($tokens);
+		$tokens = $this->inlineModifierFilter($tokens);
 		return $tokens;
 	}
 
@@ -205,6 +206,65 @@ class PhpWriter
 			$res->append(' : NULL');
 		}
 		return $res;
+	}
+
+
+	public function inlineModifierFilter(MacroTokens $tokens)
+	{
+		$result = new MacroTokens();
+		while ($tokens->nextToken()) {
+			if ($tokens->isCurrent('(', '[')) {
+				$result->tokens = array_merge($result->tokens, $this->inlineModifiersFilterInner($tokens));
+			} else {
+				$result->append($tokens->currentToken());
+			}
+		}
+
+		return $result;
+	}
+
+	private function inlineModifiersFilterInner(MacroTokens $tokens)
+	{
+		$isFunctionOrArray = $tokens->isPrev(MacroTokens::T_VARIABLE, MacroTokens::T_SYMBOL) || $tokens->isCurrent('[');
+		$result = new MacroTokens();
+		$args = new MacroTokens();
+		$modifiers = new MacroTokens();
+		$current = $args;
+		$anyModifier = FALSE;
+		$result->append($tokens->currentToken());
+
+		while ($tokens->nextToken()) {
+			if ($tokens->isCurrent('(', '[')) {
+				$current->tokens = array_merge($current->tokens, $this->inlineModifiersFilterInner($tokens));
+			} elseif ($current !== $modifiers && $tokens->isCurrent('|')) {
+				$anyModifier = TRUE;
+				$current = $modifiers;
+			} elseif ($tokens->isCurrent(')', ']') || ($isFunctionOrArray && $tokens->isCurrent(','))) {
+				if (count($modifiers->tokens)) {
+					$partTokens = $this->modifiersFilter($modifiers, $args->tokens)->tokens;
+				} else {
+					$partTokens = $args->tokens;
+				}
+				$result->tokens = array_merge($result->tokens, $partTokens);
+				if (!$tokens->isCurrent(',')) {
+					if ($isFunctionOrArray || !$anyModifier) {
+						$result->append($tokens->currentToken());
+					} else {
+						array_shift($result->tokens);
+					}
+
+					return $result->tokens;
+				}
+				//comma
+				$result->append($tokens->currentToken());
+				$args = new MacroTokens();
+				$modifiers = new MacroTokens();
+				$current = $args;
+			} else {
+				$current->append($tokens->currentToken());
+			}
+		}
+		throw new CompileException('Unbalanced brackets.');
 	}
 
 

--- a/tests/Latte/Parser.parseMacroTag.phpt
+++ b/tests/Latte/Parser.parseMacroTag.phpt
@@ -55,3 +55,7 @@ Assert::same(['=', '-10', '', FALSE], $parser->parseMacroTag('-10'));
 Assert::same(['=', '$var', "|mod:'\\':a:b:c':arg2 |mod2:|mod3", FALSE], $parser->parseMacroTag("\$var |mod:'\\':a:b:c':arg2 |mod2:|mod3"));
 Assert::same(['=', '$var', '|mod|mod2|noescape', FALSE], $parser->parseMacroTag('$var|mod|mod2|noescape'));
 Assert::same(['=', "'a|b\\'c'", '', FALSE], $parser->parseMacroTag("'a|b\\'c'"));
+
+Assert::same(['link', 'foo => ($var|mod)', '|mod2', FALSE], $parser->parseMacroTag('link foo => ($var|mod)|mod2'));
+Assert::same(['link', 'foo => ($var|mod)', '|mod2:(1|foo)', FALSE], $parser->parseMacroTag('link foo => ($var|mod)|mod2:(1|foo)'));
+Assert::same(['link', 'foo => "(aa"', '|mod2:"bb)"', FALSE], $parser->parseMacroTag('link foo => "(aa"|mod2:"bb)"'));

--- a/tests/Latte/PhpWriter.formatArgs().phpt
+++ b/tests/Latte/PhpWriter.formatArgs().phpt
@@ -85,3 +85,15 @@ test(function () { // special UTF-8
 	Assert::same("'M_PIÁNO'",  formatArgs('M_PIÁNO'));
 	Assert::same("'symbôl-1' => 'vålue-2'",  formatArgs('symbôl-1 => vålue-2'));
 });
+
+test(function () {
+	Assert::same("'foo' => \$template->mod(\$val, 'param', \"param2)\")", formatArgs('foo => ($val|mod:param:"param2)")'));
+	Assert::same("'foo' => \$template->mod2(\$template->mod(\$val))", formatArgs('foo => ($val|mod|mod2)'));
+	Assert::same("'foo' => \$template->mod(\$val, 'param', \$template->mod2(1))", formatArgs('foo => ($val|mod:param:(1|mod2))'));
+	Assert::same("'foo' => \$template->mod(\$val, 'param', \$template->mod2(1, round(\$template->foo(2))))", formatArgs('foo => ($val|mod:param:(1|mod2:round((2|foo))))'));
+	Assert::same("'foo' => foo(\$val)", formatArgs('foo => foo($val)'));
+	Assert::same("'foo' => foo(\$template->bar(\$val))", formatArgs('foo => foo($val|bar)'));
+	Assert::same("foo(\$template->bar(\$val),\$template->lorem( \$val))", formatArgs('foo($val|bar, $val|lorem)'));
+	Assert::same("'foo' => array(\$template->bar(\$val),)", formatArgs('foo => array($val|bar,)'));
+	Assert::same("[\$template->bar(\$val),\$template->lorem( \$val)]", formatArgs('[$val|bar, $val|lorem]'));
+});

--- a/tests/Latte/PhpWriter.formatModifiers().phpt
+++ b/tests/Latte/PhpWriter.formatModifiers().phpt
@@ -49,3 +49,7 @@ test(function () { // arguments
 	Assert::same('$template->mod(@, \'True\', \'False\', \'Null\')',  formatModifiers('@', 'mod: True, False, Null'));
 	Assert::same('$template->mod(@, array(1))',  formatModifiers('@', 'mod: array(1)'));
 });
+
+test(function() {
+	Assert::same('$template->mod(@, $template->mod2(2))', formatModifiers('@', 'mod:(2|mod2)'));
+});


### PR DESCRIPTION
Motivation:
Sometimes I need to apply the filter only on a part of macro arguments.

Current state:
```latte
{link default foo => $template->mod2($template->mod($name, 123))}
```

Proposal:
```latte
{link this slug => ($name|mod:123|mod2)}
```

You can also use inline filters on arguments of other filters
```
{$foo|replace:'foo':($replacement|lower)}
```