### PR TITLE
Failing test: not escaped included block in meta tag

### DIFF
--- a/tests/Latte/expected/macros.include-escape.html
+++ b/tests/Latte/expected/macros.include-escape.html
@@ -1,0 +1,4 @@
+
+<title>Search: trtr1;url=data:text;base64,PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD4=" HTTP-EQUIV="refresh" t="</title>
+
+<meta property="og:title" content="Search: trtr1;url=data:text;base64,PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD4=&quot; HTTP-EQUIV=&quot;refresh&quot; t=&quot;">

--- a/tests/Latte/macros.include.phpt
+++ b/tests/Latte/macros.include.phpt
@@ -25,6 +25,10 @@ Assert::matchFile(
 	)
 );
 Assert::matchFile(
+	__DIR__ . '/expected/macros.include-escape.html',
+	$latte->renderToString(__DIR__ . '/templates/include-escape.latte')
+);
+Assert::matchFile(
 	__DIR__ . '/expected/macros.include.inc1.phtml',
 	file_get_contents($latte->getCacheFile(__DIR__ . '/templates/subdir/include1.latte'))
 );

--- a/tests/Latte/templates/include-escape.latte
+++ b/tests/Latte/templates/include-escape.latte
@@ -1,0 +1,5 @@
+{var $query = 'trtr1;url=data:text;base64,PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD4=" HTTP-EQUIV="refresh" t="'}
+
+<title>{block title}Search: {$query}{/block}</title>
+
+<meta property="og:title" content="{include title}">


### PR DESCRIPTION
It is very simple to use Latte incorrectly without correct escape.