### PR TITLE
Update nl2br to return Latte\Runtime\Html object to prevent a need for …

### DIFF
--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -270,7 +270,7 @@ class Filters
 	 */
 	public static function nl2br($value)
 	{
-		return nl2br($value, self::$xhtml);
+		return new Html(nl2br($value, self::$xhtml));
 	}
 
 

--- a/tests/Latte/Filters.nl2br().phpt
+++ b/tests/Latte/Filters.nl2br().phpt
@@ -14,7 +14,7 @@ require __DIR__ . '/../bootstrap.php';
 $input = "Hello\nmy\r\nfriend\n\r";
 
 Filters::$xhtml = TRUE;
-Assert::same( "Hello<br />\nmy<br />\r\nfriend<br />\n\r", Filters::nl2br($input) );
+Assert::same( "Hello<br />\nmy<br />\r\nfriend<br />\n\r", (string) Filters::nl2br($input) );
 
 Filters::$xhtml = FALSE;
-Assert::same( "Hello<br>\nmy<br>\r\nfriend<br>\n\r", Filters::nl2br($input) );
+Assert::same( "Hello<br>\nmy<br>\r\nfriend<br>\n\r", (string) Filters::nl2br($input) );


### PR DESCRIPTION
- feature
- issues - none
- documentation - not needed
- BC break - possible

nl2br helper returns Html object instead of string. This prevents need to use `!` in `{!$foo|nl2br}` or abominations as `{$foo|escape|nl2br|noescape}`.

BC break is possible on edge use cases, but unlikely as this filter is mainly used to output the contents as a string and `Latte\Runtime\Html` object has `__toString` magic method implemented.