### PR TITLE
Revert Filters: Update nl2br to return Latte\Runtime\Html object

### DIFF
--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -270,7 +270,7 @@ class Filters
 	 */
 	public static function nl2br($value)
 	{
-		return new Html(nl2br($value, self::$xhtml));
+		return nl2br($value, self::$xhtml);
 	}
 
 

--- a/tests/Latte/Filters.nl2br().phpt
+++ b/tests/Latte/Filters.nl2br().phpt
@@ -14,7 +14,7 @@ require __DIR__ . '/../bootstrap.php';
 $input = "Hello\nmy\r\nfriend\n\r";
 
 Filters::$xhtml = TRUE;
-Assert::same( "Hello<br />\nmy<br />\r\nfriend<br />\n\r", (string) Filters::nl2br($input) );
+Assert::same( "Hello<br />\nmy<br />\r\nfriend<br />\n\r", Filters::nl2br($input) );
 
 Filters::$xhtml = FALSE;
-Assert::same( "Hello<br>\nmy<br>\r\nfriend<br>\n\r", (string) Filters::nl2br($input) );
+Assert::same( "Hello<br>\nmy<br>\r\nfriend<br>\n\r", Filters::nl2br($input) );


### PR DESCRIPTION
Former change could cause potential hidden XSS errors as the whole string was being unescaped.

This reverts commit 86b55f5d8e7b0ed182404df987107e905a7f974f.