### PR TITLE
Method loadCacheFile() is public

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -153,7 +153,7 @@ class Engine extends Object
 	/**
 	 * @return void
 	 */
-	private function loadCacheFile($name)
+	public function loadCacheFile($name)
 	{
 		if (!$this->tempDirectory) {
 			eval('?>' . $this->compile($name));


### PR DESCRIPTION
Makes simple way to compile Latte files globally:

```php
foreach (\Nette\Utils\Finder::findFiles("*.latte")->from(APP_DIR) as $file) {
     $latteEngine->createCache($file->getRealPath());
}
```