### PR TITLE
Engine: warmupCache()

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -149,6 +149,25 @@ class Engine extends Object
 
 
 	/**
+	 * Puts specific latte to cache
+	 * @param string $name
+	 *
+	 * @throws \Latte\RuntimeException
+	 */
+	public function warmupCache($name)
+	{
+		if (!isset($this->tempDirectory)) {
+			throw new RuntimeException('Temp directory is not set, so putting to cache is useless.');
+		}
+
+		$class = $this->getTemplateClass($name);
+		if (!class_exists($class, FALSE)) {
+			$this->loadCacheFile($name);
+		}
+	}
+
+
+	/**
 	 * @return void
 	 */
 	private function loadCacheFile($name)

--- a/tests/Latte/Engine.warmupCache.phpt
+++ b/tests/Latte/Engine.warmupCache.phpt
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Test: Latte\Engine: {warmupCache}
+ */
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+test(function () {
+	$precachedDir =__DIR__.'/../tmp/';
+	$template = __DIR__.'/templates/general.latte';
+
+	$latte = new Latte\Engine;
+	$latte->setTempDirectory($precachedDir);
+
+	$cachedFile = $latte->getCacheFile($template);
+	@unlink($cachedFile);
+	Assert::false(file_exists($cachedFile));
+
+	$latte->warmupCache($template);
+	Assert::true(file_exists($cachedFile));
+});


### PR DESCRIPTION
- feature
- issues - #55
- BC break - no

Caching named lattes without rendering.




usage:
 ```php
$latte = new Latte\Engine;
$latte->setTempDirectory('/myCache');

$latte->warmupCache('something.latte');
```

note: Temp Directory must be set for point of this functionality