### PR TITLE
Parser: Fix php error when empty input

### DIFF
--- a/src/Latte/Parser.php
+++ b/src/Latte/Parser.php
@@ -418,6 +418,10 @@ class Parser extends Object
 
 	public function getLine()
 	{
+		if (empty($this->input)) {
+			return 1;
+		}
+
 		return substr_count($this->input, "\n", 0, max(1, $this->offset - 1)) + 1;
 	}
 


### PR DESCRIPTION
When template file is not in valid UTF-8 format, PHP warning is raised:
```
substr_count(): Length value 1 exceeds string length
```
This PR fixes this warning and let's Latte throw `CompileException` as it is expected.