### PR TITLE
Engine: fixed CompileException sourceLine on PHP7

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -222,8 +222,8 @@ class Engine extends Object
 				throw $e->setSource($code, $error['line'], $name . ' (compiled)');
 			}
 		} catch (\ParseError $e) {
-			$e = new CompileException('Error in template: ' . $e->getMessage(), 0, $e);
-			throw $e->setSource($code, $e->getLine(), $name . ' (compiled)');
+			$compileException = new CompileException('Error in template: ' . $e->getMessage(), 0, $e);
+			throw $compileException->setSource($code, $e->getLine(), $name . ' (compiled)');
 		}
 		return $code;
 	}

--- a/tests/Latte/Engine.parseError.phpt
+++ b/tests/Latte/Engine.parseError.phpt
@@ -16,12 +16,13 @@ Assert::exception(function () {
 	$latte->render('{php * }');
 }, 'Latte\CompileException', "Error in template: syntax error, unexpected '*'");
 
-Assert::exception(function () {
+$e = Assert::exception(function () {
 	$latte = new Latte\Engine;
 	$latte->setTempDirectory(TEMP_DIR);
 	$latte->setLoader(new Latte\Loaders\StringLoader);
 	$latte->render('{php * * }');
 }, 'Latte\CompileException', "Error in template: syntax error, unexpected '*'");
+Assert::same(13, $e->sourceLine);
 
 if (PHP_VERSION_ID < 50400) {
 	die(0); // otherwise PHP exits with code 255


### PR DESCRIPTION
it is ok in the master, but in v2.3 branch, `$e` is overwritten and wrong line number is passed to the CompileException.