### PR TITLE
Expose "length" filter, make it work with Countable objects

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -65,6 +65,7 @@ class Engine
 		'firstupper' => 'Latte\Runtime\Filters::firstUpper',
 		'implode' => 'implode',
 		'indent' => 'Latte\Runtime\Filters::indent',
+		'length' => 'Latte\Runtime\Filters::length',
 		'lower' => 'Latte\Runtime\Filters::lower',
 		'nl2br' => 'Latte\Runtime\Filters::nl2br',
 		'number' => 'number_format',

--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -366,13 +366,13 @@ class Filters
 	 */
 	public static function length($s)
 	{
-	    if (is_array($s) || $s instanceof \Countable) {
-	        return count($s);
-	    } elseif ($s instanceof \Traversable) {
-	        return iterator_count($s);
-	    } else {
-	        return strlen(utf8_decode($s)); // fastest way
-	    }
+		if (is_array($s) || $s instanceof \Countable) {
+			return count($s);
+		} elseif ($s instanceof \Traversable) {
+			return iterator_count($s);
+		} else {
+			return strlen(utf8_decode($s)); // fastest way
+		}
 	}
 
 

--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -366,7 +366,9 @@ class Filters
 	 */
 	public static function length($s)
 	{
-		return strlen(utf8_decode($s)); // fastest way
+		return is_string($s) ? 
+			strlen(utf8_decode($s)) : // fastest way
+			count($s);
 	}
 
 

--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -366,8 +366,8 @@ class Filters
 	 */
 	public static function length($s)
 	{
-		return is_string($s) ? 
-			strlen(utf8_decode($s)) : // fastest way
+		return is_string($s) ?
+			strlen(utf8_decode($s)): // fastest way
 			count($s);
 	}
 

--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -366,9 +366,13 @@ class Filters
 	 */
 	public static function length($s)
 	{
-		return is_string($s) ?
-			strlen(utf8_decode($s)): // fastest way
-			count($s);
+	    if (is_array($s) || $s instanceof \Countable) {
+	        return count($s);
+	    } elseif ($s instanceof \Traversable) {
+	        return iterator_count($s);
+	    } else {
+	        return strlen(utf8_decode($s)); // fastest way
+	    }
 	}
 
 

--- a/tests/Latte/Filters.length().phpt
+++ b/tests/Latte/Filters.length().phpt
@@ -13,21 +13,23 @@ require __DIR__ . '/../bootstrap.php';
 
 Assert::same(0,  Filters::length(''));
 Assert::same(20,  Filters::length("I\xc3\xb1t\xc3\xabrn\xc3\xa2ti\xc3\xb4n\xc3\xa0liz\xc3\xa6ti\xc3\xb8n")); // Iñtërnâtiônàlizætiøn
-Assert::same(2,  Filters::length(array('one', 'two')));
+Assert::same(2,  Filters::length(['one', 'two']));
 
 
 class CountableClass implements Countable
 {
-	public function count() { return 4; }
+	public function count() {
+		return 4;
+	}
 }
 Assert::same(4,  Filters::length(new CountableClass()));
 
 
 class TraversableClass implements IteratorAggregate
 {
-	private $array = array('one', 'two', 'three');
+	private $array = ['one', 'two', 'three'];
 	public function getIterator() {
 		return new ArrayIterator($this->array);
-    }
+	}
 }
 Assert::same(3,  Filters::length(new TraversableClass()));

--- a/tests/Latte/Filters.length().phpt
+++ b/tests/Latte/Filters.length().phpt
@@ -13,3 +13,21 @@ require __DIR__ . '/../bootstrap.php';
 
 Assert::same(0,  Filters::length(''));
 Assert::same(20,  Filters::length("I\xc3\xb1t\xc3\xabrn\xc3\xa2ti\xc3\xb4n\xc3\xa0liz\xc3\xa6ti\xc3\xb8n")); // Iñtërnâtiônàlizætiøn
+Assert::same(2,  Filters::length(array('one', 'two')));
+
+
+class CountableClass implements Countable
+{
+	public function count() { return 4; }
+}
+Assert::same(4,  Filters::length(new CountableClass()));
+
+
+class TraversableClass implements IteratorAggregate
+{
+	private $array = array('one', 'two', 'three');
+	public function getIterator() {
+		return new ArrayIterator($this->array);
+    }
+}
+Assert::same(3,  Filters::length(new TraversableClass()));


### PR DESCRIPTION
I needed to count the number of elements in an array ...
I saw that this feature has been talked about in issue #33

I wasn't sure if I should have created a new filter `|count` for objects only ... Tell me what you think!