### PR TITLE
Respect null coalesce operator

### DIFF
--- a/src/Latte/MacroTokens.php
+++ b/src/Latte/MacroTokens.php
@@ -48,7 +48,7 @@ class MacroTokens extends TokenIterator
 			self::T_VARIABLE => '\$[\w\pL_]+',
 			self::T_NUMBER => '[+-]?[0-9]+(?:\.[0-9]+)?(?:e[0-9]+)?',
 			self::T_SYMBOL => '[\w\pL_]+(?:-[\w\pL_]+)*',
-			self::T_CHAR => '::|=>|->|\+\+|--|<<|>>|<=|>=|===|!==|==|!=|<>|&&|\|\||[^"\']', // =>, any char except quotes
+			self::T_CHAR => '::|=>|->|\+\+|--|<<|>>|<=|>=|===|!==|==|!=|<>|&&|\|\||\?\?|[^"\']', // =>, any char except quotes
 		], 'u');
 		return self::$tokenizer->tokenize($s);
 	}

--- a/src/Latte/PhpWriter.php
+++ b/src/Latte/PhpWriter.php
@@ -245,8 +245,8 @@ class PhpWriter
 		$res = new MacroTokens;
 		while ($tokens->nextToken()) {
 			$res->append($tokens->isCurrent(MacroTokens::T_SYMBOL)
-				&& (!$tokens->isPrev() || $tokens->isPrev(',', '(', '[', '=>', ':', '?', '.', '<', '>', '<=', '>=', '===', '!==', '==', '!=', '<>', '&&', '||', '=', 'and', 'or', 'xor'))
-				&& (!$tokens->isNext() || $tokens->isNext(',', ';', ')', ']', '=>', ':', '?', '.', '<', '>', '<=', '>=', '===', '!==', '==', '!=', '<>', '&&', '||', 'and', 'or', 'xor'))
+				&& (!$tokens->isPrev() || $tokens->isPrev(',', '(', '[', '=>', ':', '?', '.', '<', '>', '<=', '>=', '===', '!==', '==', '!=', '<>', '&&', '||', '=', 'and', 'or', 'xor', '??'))
+				&& (!$tokens->isNext() || $tokens->isNext(',', ';', ')', ']', '=>', ':', '?', '.', '<', '>', '<=', '>=', '===', '!==', '==', '!=', '<>', '&&', '||', 'and', 'or', 'xor', '??'))
 				? "'" . $tokens->currentValue() . "'"
 				: $tokens->currentToken()
 			);

--- a/tests/Latte/PhpWriter.formatArgs().phpt
+++ b/tests/Latte/PhpWriter.formatArgs().phpt
@@ -56,6 +56,7 @@ test(function () { // short ternary operators
 	Assert::same("(\$first ? 'first' : NULL), \$var ? 'foo' : 'bar', \$var ? 'foo' : NULL",  formatArgs('($first ? first), $var ? foo : bar, $var ? foo'));
 	Assert::same("('a' ? 'b' : NULL) ? ('c' ? 'd' : NULL) : NULL",  formatArgs('(a ? b) ? (c ? d)'));
 	Assert::same("fce() ? 'a' : NULL, fce() ? 'b' : NULL",  formatArgs('fce() ? a, fce() ? b'));
+	Assert::same("fce() ?? 'a'",  formatArgs('fce() ?? a')); //null coalesce is ignored
 });
 
 


### PR DESCRIPTION
Now it is treated as a short ternary