### PR TITLE
[WIP] Template with {contentType ...} rendered to string should not modify global application state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         - php: hhvm
 
 script:
-    - vendor/bin/tester tests -s -p php -c tests/php-unix.ini
+    - vendor/bin/tester tests -s -p php-cgi -c tests/php-unix.ini
     - php temp/code-checker/src/code-checker.php --short-arrays -i use.latte
 
 after_failure:

--- a/tests/Latte/Engine.renderToString.phpt
+++ b/tests/Latte/Engine.renderToString.phpt
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Test: Latte\Engine::renderToString()
+ */
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+test(function () {
+	$template_text = __DIR__ . '/templates/contentType-text.latte';
+	$template_mime = __DIR__ . '/templates/contentType-mime.latte';
+
+	$latte = new Latte\Engine;
+	$latte->setTempDirectory(TEMP_DIR);
+
+	Assert::equal("Content\n", $latte->renderToString($template_text));
+	Assert::equal([], headers_list());
+
+	Assert::equal("Content\n", $latte->renderToString($template_mime));
+	Assert::equal([], headers_list()); // should not affect global state
+});

--- a/tests/Latte/templates/contentType-mime.latte
+++ b/tests/Latte/templates/contentType-mime.latte
@@ -1,0 +1,2 @@
+{contentType plain/text}
+Content

--- a/tests/Latte/templates/contentType-text.latte
+++ b/tests/Latte/templates/contentType-text.latte
@@ -1,0 +1,2 @@
+{contentType text}
+Content

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,4 +1,6 @@
 [PHP]
+expose_php = off
+
 ;extension_dir = "./ext"
 
 [Zend]

--- a/tests/php-win.ini
+++ b/tests/php-win.ini
@@ -1,4 +1,6 @@
 [PHP]
+expose_php = off
+
 extension_dir = "./ext"
 extension=php_mbstring.dll
 extension=php_fileinfo.dll


### PR DESCRIPTION
Anything rendered to string should not modify global application state. Unfortunately it is not a case with macro `{contentType mime-type}` which sets headers directly. [ref to latte code](https://github.com/nette/latte/blob/62666d98954c92c0a18e55bfa36343dc2a8d8270/src/Latte/Macros/CoreMacros.php#L446)

Expected behaviour would be to:
1. `render()` method modifies application output directly, it is expected to modify output headers
2. `renderToString()` should NOT modify headers - there should be some other API to get headers set by template