### PR TITLE
Latte\Engine: add getProviders method

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -294,6 +294,16 @@ class Engine
 
 
 	/**
+	 * Returns all providers.
+	 * @return array
+	 */
+	public function getProviders()
+	{
+		return $this->providers;
+	}
+
+
+	/**
 	 * @return self
 	 */
 	public function setContentType($type)

--- a/tests/Latte/Engine.providers.phpt
+++ b/tests/Latte/Engine.providers.phpt
@@ -1,0 +1,19 @@
+<?php
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$latte = new Latte\Engine;
+
+$latte->addProvider('provider_1', 'value_1');
+$latte->addProvider('provider_2', 'value_2');
+$latte->addProvider('provider_3', 'value_3');
+
+Assert::same([
+	'provider_1' => 'value_1',
+	'provider_2' => 'value_2',
+	'provider_3' => 'value_3',
+], $latte->getProviders());


### PR DESCRIPTION
This method allows to get all providers passed to the Latte\Engine using method Latte\Engine::addProvider. It useful for example when you have custom Template object and you need to work there with providers.

see: https://forum.nette.org/cs/26250-pojdte-otestovat-nette-2-4-rc?p=3#p175305