### PR TITLE
Filters: remove use of length from truncate & substring methods

### DIFF
--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -424,7 +424,7 @@ class Filters
 	public static function substring($s, $start, $length = NULL)
 	{
 		if ($length === NULL) {
-			$length = self::length($s);
+			$length = strlen(utf8_decode($s));
 		}
 		if (function_exists('mb_substr')) {
 			return mb_substr($s, $start, $length, 'UTF-8'); // MB is much faster
@@ -442,8 +442,8 @@ class Filters
 	 */
 	public static function truncate($s, $maxLen, $append = "\xE2\x80\xA6")
 	{
-		if (self::length($s) > $maxLen) {
-			$maxLen = $maxLen - self::length($append);
+		if (strlen(utf8_decode($s)) > $maxLen) {
+			$maxLen = $maxLen - strlen(utf8_decode($append));
 			if ($maxLen < 1) {
 				return $append;
 

--- a/tests/Latte/Filters.substring().phpt
+++ b/tests/Latte/Filters.substring().phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: Latte\Runtime\Filters::substring()
+ */
+
+use Latte\Runtime\Filters;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$s = "\xc5\x98ekn\xc4\x9bte, jak se (dnes) m\xc3\xa1te?"; // Řekněte, jak se (dnes) máte?
+
+
+Assert::same('?', Filters::substring($s, -1));
+Assert::same('Řekněte, jak se (dnes) máte?', Filters::substring($s, 0));
+Assert::same('Řekněte, jak se (dnes) máte?', Filters::substring($s, 0, 99));
+Assert::same('ekněte, jak se (dnes) máte?', Filters::substring($s, 1));
+Assert::same('ě', Filters::substring($s, 4, 1));
+
+
+class CountableTraversableStringClass implements Countable, IteratorAggregate
+{
+	private $name;
+
+	public function __construct($name)
+	{
+		$this->name = $name;
+	}
+
+	public function __toString()
+	{
+		return (string)$this->name;
+	}
+
+	public function count()
+	{
+		return 0;
+	}
+
+	public function getIterator()
+	{
+		return new ArrayIterator([]);
+	}
+}
+
+Assert::same('ě', Filters::substring(new CountableTraversableStringClass($s), 4, 1));

--- a/tests/Latte/Filters.truncate().phpt
+++ b/tests/Latte/Filters.truncate().phpt
@@ -47,3 +47,31 @@ Assert::same('Řekněte, jak se (dnes) máte?', Filters::truncate($s, 29)); // l
 Assert::same('Řekněte, jak se (dnes) máte?', Filters::truncate($s, 30)); // length=30
 Assert::same('Řekněte, jak se (dnes) máte?', Filters::truncate($s, 31)); // length=31
 Assert::same('Řekněte, jak se (dnes) máte?', Filters::truncate($s, 32)); // length=32
+
+
+class CountableTraversableStringClass implements Countable, IteratorAggregate
+{
+	private $name;
+
+	public function __construct($name)
+	{
+		$this->name = $name;
+	}
+
+	public function __toString()
+	{
+		return (string)$this->name;
+	}
+
+	public function count()
+	{
+		return 0;
+	}
+
+	public function getIterator()
+	{
+		return new ArrayIterator([]);
+	}
+}
+
+Assert::same('Řekněte, jak…', Filters::truncate(new CountableTraversableStringClass($s), 13)); // length=13


### PR DESCRIPTION
`Filters::truncate` & `Filters::substring` should not use `Filters::length` because posibility of object which is `Countable` or `Traversable` and has magic method `__toString`.

For example, in Latte `{$article}` works well, but `{$article|truncate:20}` don't and that is imho inconsistent behaviour. What do you think?