### PR TITLE
CoreMacros: translate macro does not use output buffer when possible

### DIFF
--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -207,13 +207,18 @@ class CoreMacros extends MacroSet
 	public function macroTranslate(MacroNode $node, PhpWriter $writer)
 	{
 		if ($node->closing) {
-			return $writer->write('$_fi = new LR\FilterInfo(%var); echo %modifyContent($this->filters->filterContent("translate", $_fi, ob_get_clean()))', $node->context[0]);
+			if (strpos($node->content, '<?php') === FALSE) {
+				$value = var_export($node->content, TRUE);
+				$node->content = '';
+			} else {
+				$node->openingCode = '<?php ob_start(function () {}) ?>' . $node->openingCode;
+				$value = 'ob_get_clean()';
+			}
+
+			return $writer->write('$_fi = new LR\FilterInfo(%var); echo %modifyContent($this->filters->filterContent("translate", $_fi, %raw))', $node->context[0], $value);
 
 		} elseif ($node->empty = ($node->args !== '')) {
 			return $writer->write('echo %modify(call_user_func($this->filters->translate, %node.args))');
-
-		} else {
-			return 'ob_start(function () {})';
 		}
 	}
 

--- a/tests/Latte/expected/filters.general.html
+++ b/tests/Latte/expected/filters.general.html
@@ -6,6 +6,7 @@
 	<li>truncate: hello…</li>
 	<li>date: 02.01.2008 00:00:00</li>
 	<li>translated: dl…</li>
+	<li>Translated HTML: dlroW olleH</li>
 	<li>Translated HTML: joha</li>
 	<li>Translated HTML: joha</li>
 	<li>Translated HTML: johajohajohajoha|joha</li>

--- a/tests/Latte/expected/filters.general.phtml
+++ b/tests/Latte/expected/filters.general.phtml
@@ -15,38 +15,43 @@ class Template%a% extends Latte\Runtime\Template
 	<li>truncate: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->lower, call_user_func($this->filters->truncate, $hello, "10 "))) /* line 6 */ ?></li>
 	<li>date: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->date, $date, '%d.%m.%Y %H:%M:%S')) /* line 7 */ ?></li>
 	<li>translated: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->truncate, call_user_func($this->filters->translate, $hello), 3)) ?></li>
-	<li>Translated HTML: <?php ob_start(function () {}) ?>ahoj<?php
+	<li>Translated HTML: <?php
+		ob_start(function () {});
+		echo LR\Filters::escapeHtmlText($hello) /* line 9 */;
 		$_fi = new LR\FilterInfo('html');
 		echo LR\Filters::convertTo($_fi, 'html', $this->filters->filterContent("translate", $_fi, ob_get_clean())) ?></li>
-	<li>Translated HTML: <?php ob_start(function () {}) ?>ahoj<?php
+	<li>Translated HTML: <?php
 		$_fi = new LR\FilterInfo('html');
-		echo LR\Filters::convertTo($_fi, 'html', $this->filters->filterContent("translate", $_fi, ob_get_clean())) ?></li>
+		echo LR\Filters::convertTo($_fi, 'html', $this->filters->filterContent("translate", $_fi, 'ahoj')) ?></li>
+	<li>Translated HTML: <?php
+		$_fi = new LR\FilterInfo('html');
+		echo LR\Filters::convertTo($_fi, 'html', $this->filters->filterContent("translate", $_fi, 'ahoj')) ?></li>
 	<li>Translated HTML: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->translate, 'ahoj|ahojahojahojahoj')) ?></li>
-	<li>spaces: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello , '' , "" , "$hello" )) /* line 12 */ ?></li>
-	<li>dynamic: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->dynamic, $hello)) /* line 13 */ ?> <?php
-		echo LR\Filters::escapeHtmlText(call_user_func($this->filters->dynamic2, $hello)) /* line 13 */ ?></li>
+	<li>spaces: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello , '' , "" , "$hello" )) /* line 13 */ ?></li>
+	<li>dynamic: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->dynamic, $hello)) /* line 14 */ ?> <?php
+		echo LR\Filters::escapeHtmlText(call_user_func($this->filters->dynamic2, $hello)) /* line 14 */ ?></li>
 </ul>
 
 <ul>
-	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->h2, call_user_func($this->filters->h1, $hello))) /* line 17 */ ?></li>
-	<li><?php echo call_user_func($this->filters->h2, call_user_func($this->filters->h1, $hello)) /* line 18 */ ?></li>
-	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->h1, call_user_func($this->filters->h2, $hello))) /* line 19 */ ?></li>
-	<li><?php echo call_user_func($this->filters->h1, call_user_func($this->filters->h2, $hello)) /* line 20 */ ?></li>
+	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->h2, call_user_func($this->filters->h1, $hello))) /* line 18 */ ?></li>
+	<li><?php echo call_user_func($this->filters->h2, call_user_func($this->filters->h1, $hello)) /* line 19 */ ?></li>
+	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->h1, call_user_func($this->filters->h2, $hello))) /* line 20 */ ?></li>
+	<li><?php echo call_user_func($this->filters->h1, call_user_func($this->filters->h2, $hello)) /* line 21 */ ?></li>
 </ul>
 
 <ul>
-	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello*0, 0, 0.0, "0")) /* line 24 */ ?></li>
-	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello*1, 1, "1")) /* line 25 */ ?></li>
-	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello, true, null, false)) /* line 26 */ ?></li>
-	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello, TRUE, NULL, FALSE)) /* line 27 */ ?></li>
-	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello, '', "", "$hello")) /* line 28 */ ?></li>
+	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello*0, 0, 0.0, "0")) /* line 25 */ ?></li>
+	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello*1, 1, "1")) /* line 26 */ ?></li>
+	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello, true, null, false)) /* line 27 */ ?></li>
+	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello, TRUE, NULL, FALSE)) /* line 28 */ ?></li>
+	<li><?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->types, $hello, '', "", "$hello")) /* line 29 */ ?></li>
 </ul>
 
 
 
 <?php ob_start(function () {}) ?>
 <ul>
-	<li>lower: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->lower, $hello)) /* line 35 */ ?></li>
+	<li>lower: <?php echo LR\Filters::escapeHtmlText(call_user_func($this->filters->lower, $hello)) /* line 36 */ ?></li>
 </ul>
 <?php
 		$_fi = new LR\FilterInfo('html');
@@ -54,7 +59,7 @@ class Template%a% extends Latte\Runtime\Template
 ?>
 
 <p>
-Captured: <?php echo LR\Filters::escapeHtmlText($capture) /* line 40 */ ?>
+Captured: <?php echo LR\Filters::escapeHtmlText($capture) /* line 41 */ ?>
 
 </p>
 
@@ -67,7 +72,7 @@ Hello
 ?>
 
 <p>
-Captured with modifier: <?php echo LR\Filters::escapeHtmlText($capture) /* line 49 */ ?>
+Captured with modifier: <?php echo LR\Filters::escapeHtmlText($capture) /* line 50 */ ?>
 
 </p>
 

--- a/tests/Latte/templates/filters.general.latte
+++ b/tests/Latte/templates/filters.general.latte
@@ -6,6 +6,7 @@
 	<li>truncate: {$hello |truncate:"10 "|lower}</li>
 	<li>date: {$date|date:'%d.%m.%Y %H:%M:%S'}</li>
 	<li>translated: {_$hello|truncate:3}</li>
+	<li>Translated HTML: {_}{$hello}{/_}</li>
 	<li>Translated HTML: {_}ahoj{/_}</li>
 	<li>Translated HTML: {_}ahoj{/}</li>
 	<li>Translated HTML: {_'ahoj|ahojahojahojahoj'}</li>


### PR DESCRIPTION
I wonder if we can drop FilterInfo as well for static content.