### PR TITLE
BlockMacros - define: fixed variables extracting

### DIFF
--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -9,7 +9,6 @@ namespace Latte\Macros;
 
 use Latte;
 use Latte\CompileException;
-use Latte\Engine;
 use Latte\Helpers;
 use Latte\MacroNode;
 use Latte\PhpWriter;
@@ -341,7 +340,8 @@ class BlockMacros extends MacroSet
 			}
 			if (empty($node->data->leave)) {
 				if (preg_match('#\$|n:#', $node->content)) {
-					$node->content = '<?php ' . (isset($node->data->args) ? $node->data->args : 'extract($_args);') . ' ?>' . $node->content;
+					$node->content = '<?php ' . (isset($node->data->args) ? 'extract($this->params); ' . $node->data->args : 'extract($_args);') . ' ?>'
+						. $node->content;
 				}
 				$this->namedBlocks[$node->data->name] = $tmp = preg_replace('#^\n+|(?<=\n)[ \t]+\z#', '', $node->content);
 				$node->content = substr_replace($node->content, $node->openingCode . "\n", strspn($node->content, "\n"), strlen($tmp));

--- a/tests/Latte/BlockMacros.defineblock.phpt
+++ b/tests/Latte/BlockMacros.defineblock.phpt
@@ -24,7 +24,7 @@ $template = <<<'EOD'
 {include #test, var => 20}
 
 {define testargs $var1, $var2}
-	Variables {$var1}, {$var2}
+	Variables {$var1}, {$var2}, {$hello}
 {/define}
 
 {include testargs, 1}
@@ -37,5 +37,5 @@ Assert::matchFile(
 );
 Assert::matchFile(
 	__DIR__ . '/expected/BlockMacros.defineblock.html',
-	$latte->renderToString($template)
+	$latte->renderToString($template, ['hello' => 'world'])
 );

--- a/tests/Latte/expected/BlockMacros.defineblock.html
+++ b/tests/Latte/expected/BlockMacros.defineblock.html
@@ -4,4 +4,4 @@
 	This is definition #20
 
 
-	Variables 1,
+	Variables 1, , world

--- a/tests/Latte/expected/BlockMacros.defineblock.phtml
+++ b/tests/Latte/expected/BlockMacros.defineblock.phtml
@@ -49,8 +49,10 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockTestargs($_args)
 	{
+		extract($this->params);
 		list($var1, $var2) = $_args + [NULL, NULL, ];
-		?>	Variables <?php echo LR\Filters::escapeHtmlText($var1) /* line 11 */ ?>, <?php echo LR\Filters::escapeHtmlText($var2) /* line 11 */ ?>
+		?>	Variables <?php echo LR\Filters::escapeHtmlText($var1) /* line 11 */ ?>, <?php echo LR\Filters::escapeHtmlText($var2) /* line 11 */ ?>, <?php
+		echo LR\Filters::escapeHtmlText($hello) /* line 11 */ ?>
 
 <?php
 	}


### PR DESCRIPTION
...when named parameters are used

currently, even global variables like `$basePath` are not available...

