### PR TITLE
Auto empty macros: fix combination with a short macro closing

### DIFF
--- a/src/Latte/IMacro.php
+++ b/src/Latte/IMacro.php
@@ -17,6 +17,7 @@ interface IMacro
 		AUTO_EMPTY = 4,
 		AUTO_CLOSE = 64,
 		ALLOWED_IN_HEAD = 128,
+		PAIR = 256,
 		DEFAULT_FLAGS = 0;
 
 	/**

--- a/src/Latte/Macros/MacroSet.php
+++ b/src/Latte/Macros/MacroSet.php
@@ -44,7 +44,7 @@ class MacroSet implements Latte\IMacro
 		}
 
 		$this->macros[$name] = [$begin, $end, $attr];
-		$this->compiler->addMacro($name, $this, $flags);
+		$this->compiler->addMacro($name, $this, $flags | ($end !== NULL && $begin !== NULL ? Latte\IMacro::PAIR : 0));
 		return $this;
 	}
 

--- a/tests/Latte/Compiler.flag.AUTO_EMPTY.phpt
+++ b/tests/Latte/Compiler.flag.AUTO_EMPTY.phpt
@@ -32,6 +32,7 @@ $latte->setLoader(new Latte\Loaders\StringLoader);
 
 $macro = new TestMacro;
 $latte->getCompiler()->addMacro('test_auto', $macro, IMacro::AUTO_EMPTY);
+$latte->getCompiler()->addMacro('test_auto2', $macro, IMacro::AUTO_EMPTY);
 
 
 $latte->compile('{test_auto} ... {/test_auto}');
@@ -58,3 +59,41 @@ Assert::exception(function () use ($latte) {
 Assert::exception(function () use ($latte) {
 	$latte->compile('{test_auto} <div n:test_auto></div> {/test_auto}');
 }, 'Latte\CompileException', 'Unexpected {/test_auto}');
+
+$latte->compile('{test_auto} ... {/}');
+Assert::same(' ... ', $macro->nodes[0]->content);
+
+$latte->compile('{test_auto} {if true} ... {/}');
+Assert::null($macro->nodes[0]->content);
+
+$latte->compile('{test_auto} {test_auto2 true} ... {/}');
+Assert::null($macro->nodes[0]->content);
+Assert::same(' ... ', $macro->nodes[1]->content);
+
+$latte->compile('{test_auto}x{test_auto2 true} ... {/test_auto2}x');
+Assert::null($macro->nodes[0]->content);
+Assert::same(' ... ', $macro->nodes[1]->content);
+
+$latte->compile('{test_auto}x{test_auto2 true} ... {/test_auto2}x{/}');
+Assert::same('x ... x', $macro->nodes[0]->content);
+Assert::same(' ... ', $macro->nodes[1]->content);
+
+$latte->compile('{test_auto} {if true} {/} {/}');
+Assert::match('%A% if (true) %A%', $macro->nodes[0]->content);
+
+$latte->compile('{test_auto} {if true} {/} {/test_auto}');
+Assert::match('%A% if (true) %A%', $macro->nodes[0]->content);
+
+$latte->compile('{test_auto} {if true} {/if} {/}');
+Assert::match('%A% if (true) %A%', $macro->nodes[0]->content);
+
+$latte->compile('{test_auto} {test_auto} ... {/}');
+Assert::null($macro->nodes[0]->content);
+Assert::same(' ... ', $macro->nodes[1]->content);
+
+
+$latte->compile('{test_auto} {_}...{/}');
+Assert::null($macro->nodes[0]->content);
+
+$latte->compile('{test_auto}lorem{_ipsum}dolor{/}');
+Assert::match('lorem%a%ipsum%a%dolor', $macro->nodes[0]->content);

--- a/tests/Latte/MacroSet.basic.phpt
+++ b/tests/Latte/MacroSet.basic.phpt
@@ -50,9 +50,9 @@ test(function () use ($set) {
 
 
 test(function () use ($set) {
-	$set->addMacro('attr', 'begin', 'end', 'attr');
+	$set->addMacro('attr2', 'begin', 'end', 'attr');
 
-	$node = new MacroNode($set, 'attr');
+	$node = new MacroNode($set, 'attr2');
 	Assert::null($set->nodeOpened($node));
 	Assert::same('<?php begin ?>', $node->openingCode);
 	Assert::false($node->empty);
@@ -60,12 +60,12 @@ test(function () use ($set) {
 	Assert::null($set->nodeClosed($node));
 	Assert::same('<?php end ?>', $node->closingCode);
 
-	$node = new MacroNode($set, 'attr');
+	$node = new MacroNode($set, 'attr2');
 	$node->prefix = $node::PREFIX_NONE;
 	Assert::null($set->nodeOpened($node));
 	Assert::same('<?php attr ?>', $node->attrCode);
 
-	$node = new MacroNode($set, 'attr');
+	$node = new MacroNode($set, 'attr2');
 	$node->prefix = $node::PREFIX_INNER;
 	Assert::null($set->nodeOpened($node));
 	Assert::null($node->attrCode);


### PR DESCRIPTION
e.g. `{label foo}bar{/}`

there is a minor BC break when someone adds macro directly using a addMacro (without MacroSet) without passing correct PAIR flag.

I really don't like hardcoded `_` macro. Maybe we could introduce another flag for this?
