### PR TITLE
added {include with blocks} as a successor to {includeblock}

### DIFF
--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -186,7 +186,7 @@ class BlockMacros extends MacroSet
 	 */
 	public function macroIncludeBlock(MacroNode $node, PhpWriter $writer): string
 	{
-		//trigger_error('Tag {includeblock} is deprecated, use similar tag {import}.', E_USER_DEPRECATED);
+		//trigger_error('Macro {includeblock} is deprecated, use {include 'file.latte' with blocks} or similar macro {import}.', E_USER_DEPRECATED);
 		$node->replaced = false;
 		$node->validate(true);
 		return $writer->write(

--- a/tests/Latte/BlockMacros.include.with-blocks.phpt
+++ b/tests/Latte/BlockMacros.include.with-blocks.phpt
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Test: {include ... with blocks}
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$latte = new Latte\Engine;
+$latte->setLoader(new Latte\Loaders\StringLoader([
+	'main' => '
+{include (true ? "inc" : '') with blocks}
+
+{include test}
+	',
+
+	'inc' => '
+{define test}
+	Parent: {basename($this->getReferringTemplate()->getName())}/{$this->getReferenceType()}
+{/define}
+	',
+]));
+
+Assert::matchFile(
+	__DIR__ . '/expected/BlockMacros.include.with-blocks.phtml',
+	$latte->compile('main')
+);
+Assert::matchFile(
+	__DIR__ . '/expected/BlockMacros.include.with-blocks.html',
+	$latte->renderToString('main')
+);
+Assert::matchFile(
+	__DIR__ . '/expected/BlockMacros.include.with-blocks.inc.phtml',
+	$latte->compile('inc')
+);
+
+
+Assert::exception(function () use ($latte) {
+	$latte->setLoader(new Latte\Loaders\StringLoader);
+	$latte->renderToString('{include "inc", with blocks}');
+}, ParseError::class);

--- a/tests/Latte/BlockMacros.inheritance.child1.phpt
+++ b/tests/Latte/BlockMacros.inheritance.child1.phpt
@@ -20,7 +20,7 @@ $latte->setLoader(new Latte\Loaders\StringLoader([
 {extends "parent"}
 
 {import "inc"}
-{includeblock "inc"}
+{include "inc" with blocks}
 
 {block title}Homepage | {include parent}{include parent}{/block}
 

--- a/tests/Latte/contentType.compatibility.phpt
+++ b/tests/Latte/contentType.compatibility.phpt
@@ -180,7 +180,7 @@ $latte->setLoader(new Latte\Loaders\StringLoader([
 
 	'context1' => '<p>{include ical.latte}</p>',
 	'context2' => '{extends ical.latte}',
-	'context3' => 'x{includeblock ical.latte}',
+	'context3' => 'x{include ical.latte with blocks}',
 	'context4' => '{contentType calendar} {include ical.latte}',
 	'context5' => '<p>{include ical.latte|noescape}</p>',
 	'context6' => '{contentType javascript} {include ical.latte}',

--- a/tests/Latte/expected/BlockMacros.include.inc1.phtml
+++ b/tests/Latte/expected/BlockMacros.include.inc1.phtml
@@ -11,10 +11,10 @@ final class Template%a% extends Latte\Runtime\Template
 
 ';
 		/* line 3 */
-		$this->createTemplate("include2.latte", ['localvar' => 20] + $this->params, "include")->renderToContentType('html');
+		$this->createTemplate("include2.latte", ['localvar' => 20] + $this->params, 'include')->renderToContentType('html');
 		echo "\n";
 		/* line 5 */
-		$this->createTemplate("../include3.latte", $this->params, "include")->renderToContentType('html');
+		$this->createTemplate("../include3.latte", $this->params, 'include')->renderToContentType('html');
 		echo '
 <textarea>
 pre

--- a/tests/Latte/expected/BlockMacros.include.phtml
+++ b/tests/Latte/expected/BlockMacros.include.phtml
@@ -8,7 +8,7 @@ final class Template%a% extends Latte\Runtime\Template
 	{
 %A%
 		/* line 2 */
-		$this->createTemplate(('subdir/include1.latte' . ''), ['localvar' => 10] + $this->params, "include")->renderToContentType(function ($s, $type) {
+		$this->createTemplate(('subdir/include1.latte' . ''), ['localvar' => 10] + $this->params, 'include')->renderToContentType(function ($s, $type) {
 			$__fi = new LR\FilterInfo($type);
 			return LR\Filters::convertTo($__fi, 'html', $this->filters->filterContent('indent', $__fi, $s));
 		});

--- a/tests/Latte/expected/BlockMacros.include.with-blocks.html
+++ b/tests/Latte/expected/BlockMacros.include.with-blocks.html
@@ -1,0 +1,4 @@
+
+
+
+	Parent: main/includeblock

--- a/tests/Latte/expected/BlockMacros.include.with-blocks.inc.phtml
+++ b/tests/Latte/expected/BlockMacros.include.with-blocks.inc.phtml
@@ -1,0 +1,34 @@
+<?php
+%A%
+
+final class Template%a% extends Latte\Runtime\Template
+{
+	protected const BLOCKS = [
+		['test' => 'blockTest'],
+	];
+
+
+	public function main(): array
+	{
+		extract($this->params);
+		echo "\n";
+		if ($this->getParentName()) {
+			return get_defined_vars();
+		}
+		echo '	';
+		return get_defined_vars();
+	}
+
+
+	public function blockTest(array $__args): void
+	{
+		extract($this->params);
+		extract($__args);
+		echo '	Parent: ';
+		echo LR\Filters::escapeHtmlText(basename($this->getReferringTemplate()->getName())) /* line 3 */;
+		echo '/';
+		echo LR\Filters::escapeHtmlText($this->getReferenceType()) /* line 3 */;
+		echo "\n";
+	}
+
+}

--- a/tests/Latte/expected/BlockMacros.include.with-blocks.phtml
+++ b/tests/Latte/expected/BlockMacros.include.with-blocks.phtml
@@ -1,0 +1,17 @@
+<?php
+%A%
+
+final class Template%a% extends Latte\Runtime\Template
+{
+
+	public function main(): array
+	{
+%A%
+		/* line 2 */
+		$this->createTemplate("inc", $this->params, 'includeblock')->renderToContentType('html');
+		echo "\n";
+		$this->renderBlock($__nm = 'test', [], 'html');
+%A%
+	}
+
+}

--- a/tests/Latte/expected/BlockMacros.inheritance.child1.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child1.phtml
@@ -11,9 +11,7 @@ final class Template%a% extends Latte\Runtime\Template
 	public function main(): array
 	{
 %A%
-		ob_start(function () {});
-		$this->createTemplate("inc", get_defined_vars(), "includeblock")->renderToContentType('html');
-		echo rtrim(ob_get_clean());
+		$this->createTemplate("inc", $this->params, 'includeblock')->renderToContentType('html');
 		echo "\n";
 		if ($this->getParentName()) {
 			return get_defined_vars();


### PR DESCRIPTION
- bug fix? ~
- new feature? yes
- BC break? no

There are use cases where `{includeblock}` is useful and cannot be substituted by `{import}`. But the name `{includeblock}` is misleading. This is attempt to solve it by more understandable `{include with blocks 'file.latte'}`

Cons: this introduces syntax which is not common in Latte.

https://forum.nette.org/cs/26699-latte-vypis-bloku-do-include