### PR TITLE
Notice fix on PHP7

### DIFF
--- a/src/Latte/PhpWriter.php
+++ b/src/Latte/PhpWriter.php
@@ -69,7 +69,7 @@ class PhpWriter extends Object
 				case '':
 					$arg = next($args); break;
 				default:
-					$arg = $args[$source + 1]; break;
+					$arg = $args[(int) $source + 1]; break;
 			}
 
 			switch ($format) {


### PR DESCRIPTION
Absence of the type cast caused Notice (A non well formed numeric value encountered) to appear in the log file on PHP7 server.

- bug fix? yes
- new feature? no
- BC break? no