### PR TITLE
n:class supports BEM

### DIFF
--- a/src/Latte/Compiler/MacroTokens.php
+++ b/src/Latte/Compiler/MacroTokens.php
@@ -52,7 +52,7 @@ class MacroTokens extends TokenIterator
 			self::T_CAST => '\((?:expand|string|array|int|integer|float|bool|boolean|object)\)', // type casting
 			self::T_VARIABLE => '\$[\w\pL_]+',
 			self::T_NUMBER => '[+-]?[0-9]+(?:\.[0-9]+)?(?:e[0-9]+)?',
-			self::T_SYMBOL => '[\w\pL_]+(?:-[\w\pL_]+)*',
+			self::T_SYMBOL => '[\w\pL_]+(?:-+[\w\pL_]+)*',
 			self::T_CHAR => '::|=>|->|\+\+|--|<<|>>|<=>|<=|>=|===|!==|==|!=|<>|&&|\|\||\?\?|\?>|\*\*|\.\.\.|[^"\']', // =>, any char except quotes
 		], 'u');
 		return self::$tokenizer->tokenize($s);

--- a/tests/Latte/expected/macros.n-macros.html
+++ b/tests/Latte/expected/macros.n-macros.html
@@ -15,6 +15,7 @@
 
 <p>n:class empty</p>
 
+<p class="bem--modifier">n:class with BEM</p>
 
 
 <ul title="block + if + foreach">

--- a/tests/Latte/expected/macros.n-macros.phtml
+++ b/tests/Latte/expected/macros.n-macros.phtml
@@ -49,6 +49,7 @@ class Template%a% extends Latte\Runtime\Template
 
 <p<?php if ($_tmp = array_filter([false ? 'first' : NULL])) echo ' class="', LR\Filters::escapeHtmlAttr(implode(" ", array_unique($_tmp))), '"' ?>>n:class empty</p>
 
+<p<?php if ($_tmp = array_filter([true ? 'bem--modifier' : NULL])) echo ' class="', LR\Filters::escapeHtmlAttr(implode(" ", array_unique($_tmp))), '"' ?>>n:class with BEM</p>
 
 
 <?php
@@ -64,7 +65,7 @@ class Template%a% extends Latte\Runtime\Template
 <?php
 		$iterations = 0;
 		foreach ($people as $person) {
-			?>	<li><?php echo LR\Filters::escapeHtmlText($person) /* line 27 */ ?></li>
+			?>	<li><?php echo LR\Filters::escapeHtmlText($person) /* line 28 */ ?></li>
 <?php
 			$iterations++;
 		}
@@ -76,7 +77,7 @@ class Template%a% extends Latte\Runtime\Template
 		$iterations = 0;
 		foreach ($people as $person) {
 ?>	<li>
-		<?php echo LR\Filters::escapeHtmlText($person) /* line 32 */ ?>
+		<?php echo LR\Filters::escapeHtmlText($person) /* line 33 */ ?>
 
 	</li>
 <?php
@@ -90,7 +91,7 @@ class Template%a% extends Latte\Runtime\Template
 <?php
 		$iterations = 0;
 		foreach ($people as $person) {
-			?>		<?php echo LR\Filters::escapeHtmlText($person) /* line 38 */ ?>
+			?>		<?php echo LR\Filters::escapeHtmlText($person) /* line 39 */ ?>
 
 <?php
 			$iterations++;
@@ -104,7 +105,7 @@ class Template%a% extends Latte\Runtime\Template
 ?>	<li>
 <?php
 		}
-		?>		<?php echo LR\Filters::escapeHtmlText($person) /* line 44 */ ?>
+		?>		<?php echo LR\Filters::escapeHtmlText($person) /* line 45 */ ?>
 
 <?php
 		if (array_pop($this->global->ifs)) {
@@ -119,7 +120,7 @@ class Template%a% extends Latte\Runtime\Template
 		for ($i=0;
 		$i<3;
 		$i++) {
-			?>	<li><?php echo LR\Filters::escapeHtmlText($i) /* line 49 */ ?></li>
+			?>	<li><?php echo LR\Filters::escapeHtmlText($i) /* line 50 */ ?></li>
 <?php
 		}
 ?>
@@ -128,7 +129,7 @@ class Template%a% extends Latte\Runtime\Template
 <ul title="white">
 <?php
 		while (--$i>0) {
-			?>	<li><?php echo LR\Filters::escapeHtmlText($i) /* line 53 */ ?></li>
+			?>	<li><?php echo LR\Filters::escapeHtmlText($i) /* line 54 */ ?></li>
 <?php
 		}
 ?>
@@ -182,7 +183,7 @@ class Template%a% extends Latte\Runtime\Template
 		$iterations = 0;
 		foreach ($people as $person) {
 			if (strlen($person)===4) {
-				?>	<li><?php echo LR\Filters::escapeHtmlText($person) /* line 75 */ ?></li>
+				?>	<li><?php echo LR\Filters::escapeHtmlText($person) /* line 76 */ ?></li>
 <?php
 			}
 			$iterations++;
@@ -197,7 +198,7 @@ class Template%a% extends Latte\Runtime\Template
 			$iterations = 0;
 			foreach ($people as $person) {
 				if (strlen($person)===4) {
-					echo LR\Filters::escapeHtmlText($person) /* line 79 */;
+					echo LR\Filters::escapeHtmlText($person) /* line 80 */;
 				}
 				$iterations++;
 			}
@@ -212,7 +213,7 @@ class Template%a% extends Latte\Runtime\Template
 		$iterations = 0;
 		foreach ($people as $person) {
 			if (strlen($person)===4) {
-				?>	<li><?php echo LR\Filters::escapeHtmlText(($this->filters->lower)($person)) /* line 83 */ ?></li>
+				?>	<li><?php echo LR\Filters::escapeHtmlText(($this->filters->lower)($person)) /* line 84 */ ?></li>
 <?php
 			}
 			$iterations++;
@@ -305,7 +306,7 @@ class Template%a% extends Latte\Runtime\Template
 		$iterations = 0;
 		foreach ($people as $person) {
 			?>	<li><?php
-			echo LR\Filters::escapeHtmlText($person) /* line 100 */;
+			echo LR\Filters::escapeHtmlText($person) /* line 101 */;
 			if (TRUE) {
 				echo "</li>\n";
 				break;
@@ -322,7 +323,7 @@ class Template%a% extends Latte\Runtime\Template
 		$iterations = 0;
 		foreach ($people as $person) {
 			?>	<li><?php
-			echo LR\Filters::escapeHtmlText($person) /* line 104 */;
+			echo LR\Filters::escapeHtmlText($person) /* line 105 */;
 			if (TRUE) {
 				echo "</li>\n";
 				continue;
@@ -339,7 +340,7 @@ class Template%a% extends Latte\Runtime\Template
 	<li><?php
 		$iterations = 0;
 		foreach ($people as $person) {
-			echo LR\Filters::escapeHtmlText($person) /* line 109 */;
+			echo LR\Filters::escapeHtmlText($person) /* line 110 */;
 			if (TRUE) break;
 			$iterations++;
 		}
@@ -350,7 +351,7 @@ class Template%a% extends Latte\Runtime\Template
 	<li><?php
 		$iterations = 0;
 		foreach ($people as $person) {
-			echo LR\Filters::escapeHtmlText($person) /* line 113 */;
+			echo LR\Filters::escapeHtmlText($person) /* line 114 */;
 			if (TRUE) continue;
 			$iterations++;
 		}
@@ -375,7 +376,7 @@ class Template%a% extends Latte\Runtime\Template
 		$iterations = 0;
 		foreach ($people as $person) {
 			if (strlen($person)===4) {
-				?>	<li><?php echo LR\Filters::escapeHtmlText($person) /* line 19 */ ?></li>
+				?>	<li><?php echo LR\Filters::escapeHtmlText($person) /* line 20 */ ?></li>
 <?php
 			}
 			$iterations++;

--- a/tests/Latte/templates/macros.n-macros.latte
+++ b/tests/Latte/templates/macros.n-macros.latte
@@ -13,6 +13,7 @@
 
 <p n:class="false ? first">n:class empty</p>
 
+<p n:class="true ? bem--modifier">n:class with BEM</p>
 
 
 <ul title="block + if + foreach" n:block="bl">


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

[BEM](http://getbem.com/naming/) use `--`  for modifiers. Now it's possible to use classes like `block--hidden` in `n:class` without quotes.
