### PR TITLE
feature: added n:attr-expand macro

### DIFF
--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -84,6 +84,7 @@ class CoreMacros extends MacroSet
 
 		$me->addMacro('class', NULL, NULL, [$me, 'macroClass']);
 		$me->addMacro('attr', NULL, NULL, [$me, 'macroAttr']);
+		$me->addMacro('attr-expand', NULL, NULL, [$me, 'macroAttrExpand']);
 	}
 
 
@@ -379,6 +380,16 @@ class CoreMacros extends MacroSet
 	public function macroAttr(MacroNode $node, PhpWriter $writer)
 	{
 		return $writer->write('echo LR\Filters::htmlAttributes(%node.array);');
+	}
+
+
+	/**
+	 * Expand an array of attributes.
+	 * n:attr-expand="..."
+	 */
+	public function macroAttrExpand(MacroNode $node, PhpWriter $writer)
+	{
+		return $writer->write('echo LR\Filters::htmlAttributes( %node.word );');
 	}
 
 


### PR DESCRIPTION
The macro expands an array of attributes, similarly to n:attr.

- bug fix? no   <!-- #issue numbers, if any -->
- new feature? yes
- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

**Motivation**:
Suppose there is an array `$attributes` containing attributes for `<meta>` tag.
```php
array (
  'content' => 'width=device-width, initial-scale=1',
  'name' => 'viewport',
  'http-equiv' => NULL,
  'scheme' => NULL,
)
```		
The developer wants to achieve this HTML output:
```html
<meta content="width=device-width, initial-scale=1" name="viewport">
```
However, using `<meta n:attr="$meta">` the actual output is:
```html
<meta 0="content:width=device-width, initial-scale=1 name:viewport">
```
The developer is currently forced to use workarounds, like:
```latte
{=Nette\Utils\Html::el('meta', $attributes)}
```

**The solution**:
If attributes for a tag are present in an array, it would be simple to create the tag with an array-expanding macro:
```latte
<meta n:attr-expand="$attributes">
```
The macro itself is trivial:
```php
'echo LR\Filters::htmlAttributes( %node.word );'
```
compred to `n:attr`:
```php
'echo LR\Filters::htmlAttributes( %node.array );'
```


**Sidenote**:
In this case, the macro is used for outputting metas:
```latte
<meta n:foreach="$metas as $meta" n:attr-expand="$meta">
```
This approach is however very useful for many other cases during output generation.