### PR TITLE
feature: macro n:attr expands arrays

### DIFF
--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -378,7 +378,7 @@ class CoreMacros extends MacroSet
 	 */
 	public function macroAttr(MacroNode $node, PhpWriter $writer)
 	{
-		return $writer->write('echo LR\Filters::htmlAttributes(%node.array);');
+		return $writer->write('$_tmp = %node.array; echo LR\Filters::htmlAttributes( isset($_tmp[0]) && is_array($_tmp[0]) && count($_tmp) === 1 ? $_tmp[0] : $_tmp);');
 	}
 
 


### PR DESCRIPTION
When the first and only argument to n:attr macro is an array, expand it.

- bug fix? no
- new feature? yes
- BC break? yes, in a rare (and not really sensible) case


I opened another PR **solving the same thing** by adding a new macro here: #157


**Motivation**:
Suppose there is an array `$attributes` containing attributes for `<meta>` tag.
```php
array (
  'content' => 'width=device-width, initial-scale=1',
  'name' => 'viewport',
  'http-equiv' => NULL,
  'scheme' => NULL,
)
```		
The developer wants to achieve this HTML output:
```html
<meta content="width=device-width, initial-scale=1" name="viewport">
```
However, using `<meta n:attr="$meta">` the actual output is:
```html
<meta 0="content:width=device-width, initial-scale=1 name:viewport">
```
The developer is currently forced to use workarounds, like:
```latte
{=Nette\Utils\Html::el('meta', $attributes)}
```

**The solution**:
The `n:attr` macro be changed to expand the input array in case that:
- the macro receives an array with only a single element
- the single element is an array itself

Code:
```php
'$_tmp = %node.array; echo LR\Filters::htmlAttributes( isset($_tmp[0]) && is_array($_tmp[0]) && count($_tmp) === 1 ? $_tmp[0] : $_tmp);'
```
After the proposed change, the developer can use
```latte
<meta n:attr="$attributes">
````
with an expected result.

**Caveat**:
This change may actually lead to a changed behaviour if in an IMHO rare case someone actually wanted to output something like `<tag 0="foo:bar">` passing the array directly to the macro like
```latte
<tag n:attr="['foo' => 'bar']">
```

**Sidenote**:
In this case, the macro is used for outputting metas:
```latte
<meta n:foreach="$metas as $meta" n:attr="$meta">
```
This approach is however very useful for many other cases during output generation.