### PR TITLE
[PROOF OF CONCEPT] change variable passing logic

### DIFF
--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -287,7 +287,7 @@ class BlockMacros extends MacroSet
 		}
 		$this->blockTypes[$name] = implode($node->context);
 
-		$include = '$this->renderBlock(%var, ' . (($node->name === 'snippet' || $node->name === 'snippetArea') ? '$this->params' : 'get_defined_vars()')
+		$include = '$this->renderBlock(%var, ' . (($node->name === 'snippet' || $node->name === 'snippetArea') ? '[]' : 'get_defined_vars()')
 			. ($node->modifiers ? ', function ($s, $type) { $_fi = new LR\FilterInfo($type); return %modifyContent($s); }' : '') . ')';
 
 		if ($node->name === 'snippet') {
@@ -346,7 +346,7 @@ class BlockMacros extends MacroSet
 			}
 			if (empty($node->data->leave)) {
 				if (preg_match('#\$|n:#', $node->content)) {
-					$node->content = '<?php ' . (isset($node->data->args) ? 'extract($this->params); ' . $node->data->args : '') . 'extract($_args);' . ' ?>'
+					$node->content = '<?php extract($this->params); ' . (isset($node->data->args) ? $node->data->args : '') . ' extract($_args);' . ' ?>'
 						. $node->content;
 				}
 				$this->namedBlocks[$node->data->name] = $tmp = preg_replace('#^\n+|(?<=\n)[ \t]+\z#', '', $node->content);
@@ -357,7 +357,7 @@ class BlockMacros extends MacroSet
 				$node->content = rtrim($node->content, " \t");
 				$this->getCompiler()->addMethod(
 					$node->data->func,
-					$this->getCompiler()->expandTokens("extract(\$_args);\n?>$node->content<?php"),
+					$this->getCompiler()->expandTokens("extract(\$this->params); extract(\$_args);\n?>$node->content<?php"),
 					'$_args'
 				);
 				$node->content = '';

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -221,7 +221,7 @@ class BlockMacros extends MacroSet
 			$tokens = $node->tokenizer;
 			while ($tokens->isNext()) {
 				$args[] = $varName = $tokens->expectNextValue($tokens::T_VARIABLE);
-				$variablePassCode .= "'" . ltrim($varName, '$') . "' => $varName,";
+				$variablePassCode .= "'" . ltrim($varName, '$') . "' => $varName, ";
 				if ($tokens->isNext()) {
 					$tokens->expectNextValue(',');
 				}

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -216,12 +216,12 @@ class BlockMacros extends MacroSet
 
 		$node->data->name = $name = ltrim((string) $name, '#');
 		$args = [];
-		$variableScopePassCode = '[';
+		$variablePassCode = '[';
 		if ($node->name === 'define' || $node->name === 'block') {
 			$tokens = $node->tokenizer;
 			while ($tokens->isNext()) {
 				$args[] = $varName = $tokens->expectNextValue($tokens::T_VARIABLE);
-				$variableScopePassCode .= "'" . ltrim($varName, '$') . "' => $varName,";
+				$variablePassCode .= "'" . ltrim($varName, '$') . "' => $varName,";
 				if ($tokens->isNext()) {
 					$tokens->expectNextValue(',');
 				}
@@ -230,7 +230,7 @@ class BlockMacros extends MacroSet
 				$node->data->args = 'list(' . implode(', ', $args) . ') = $_args + [' . str_repeat('NULL, ', count($args)) . '];';
 			}
 		}
-		$variableScopePassCode .= ']';
+		$variablePassCode .= ']';
 
 		if ($name == NULL) {
 			if ($node->name === 'define') {
@@ -269,7 +269,7 @@ class BlockMacros extends MacroSet
 					} elseif ($node->modifiers) {
 						$node->modifiers .= '|escape';
 					}
-					$node->closingCode = $writer->write('<?php $this->renderBlock(%raw, ' . $variableScopePassCode
+					$node->closingCode = $writer->write('<?php $this->renderBlock(%raw, ' . $variablePassCode
 						. ($node->modifiers ? ', function ($s, $type) { $_fi = new LR\FilterInfo($type); return %modifyContent($s); }' : '') . '); ?>', $fname);
 				}
 				$blockType = var_export(implode($node->context), TRUE);
@@ -304,7 +304,7 @@ class BlockMacros extends MacroSet
 		}
 		$this->blockTypes[$name] = implode($node->context);
 
-		$include = '$this->renderBlock(%var, ' . (($node->name === 'snippet' || $node->name === 'snippetArea') ? '[]' : $variableScopePassCode)
+		$include = '$this->renderBlock(%var, ' . (($node->name === 'snippet' || $node->name === 'snippetArea') ? '[]' : $variablePassCode)
 			. ($node->modifiers ? ', function ($s, $type) { $_fi = new LR\FilterInfo($type); return %modifyContent($s); }' : '') . ')';
 
 		if ($node->name === 'snippet') {

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -126,7 +126,7 @@ class BlockMacros extends MacroSet
 			'$this->renderBlock' . ($parent ? 'Parent' : '') . '('
 			. (strpos($destination, '$') === FALSE ? var_export($destination, TRUE) : $destination)
 			. ', %node.array? + '
-			. (isset($this->namedBlocks[$destination]) || $parent ? 'get_defined_vars()' : '$this->params')
+			. ($parent ? '$_args' : '[]')
 			. ($node->modifiers
 				? ', function ($s, $type) { $_fi = new LR\FilterInfo($type); return %modifyContent($s); }'
 				: ($noEscape || $parent ? '' : ', ' . var_export(implode($node->context), TRUE)))

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -346,7 +346,7 @@ class BlockMacros extends MacroSet
 			}
 			if (empty($node->data->leave)) {
 				if (preg_match('#\$|n:#', $node->content)) {
-					$node->content = '<?php ' . (isset($node->data->args) ? 'extract($this->params); ' . $node->data->args : 'extract($_args);') . ' ?>'
+					$node->content = '<?php ' . (isset($node->data->args) ? 'extract($this->params); ' . $node->data->args : '') . 'extract($_args);' . ' ?>'
 						. $node->content;
 				}
 				$this->namedBlocks[$node->data->name] = $tmp = preg_replace('#^\n+|(?<=\n)[ \t]+\z#', '', $node->content);

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -147,7 +147,7 @@ class BlockMacros extends MacroSet
 			throw new CompileException('Modifiers are not allowed in ' . $node->getNotation());
 		}
 		return $writer->write(
-			'ob_start(function () {}); $this->createTemplate(%node.word, %node.array? + get_defined_vars(), "includeblock")->renderToContentType(%var); echo rtrim(ob_get_clean());',
+			'ob_start(function () {}); $this->createTemplate(%node.word, %node.array? + $this->params, "includeblock")->renderToContentType(%var); echo rtrim(ob_get_clean());',
 			implode($node->context)
 		);
 	}

--- a/tests/Latte/BlockMacros.block1.phpt
+++ b/tests/Latte/BlockMacros.block1.phpt
@@ -13,7 +13,6 @@ require __DIR__ . '/../bootstrap.php';
 
 
 $latte = new Latte\Engine;
-$latte->setTempDirectory(__DIR__ . '/../tmp');
 $latte->setLoader(new Latte\Loaders\StringLoader);
 
 Assert::match(<<<EOD

--- a/tests/Latte/BlockMacros.block1.phpt
+++ b/tests/Latte/BlockMacros.block1.phpt
@@ -13,6 +13,7 @@ require __DIR__ . '/../bootstrap.php';
 
 
 $latte = new Latte\Engine;
+$latte->setTempDirectory(__DIR__ . '/../tmp');
 $latte->setLoader(new Latte\Loaders\StringLoader);
 
 Assert::match(<<<EOD

--- a/tests/Latte/BlockMacros.dynamicblock.phpt
+++ b/tests/Latte/BlockMacros.dynamicblock.phpt
@@ -18,13 +18,13 @@ $latte->setLoader(new Latte\Loaders\StringLoader);
 $template = <<<'EOD'
 {var $var = 10}
 
-{block static}
+{block static $var}
 	Static block #{$var}
 {/block}
 
 
 {foreach [dynamic, static] as $name}
-	{block $name}
+	{block $name $var}
 		Dynamic block #{$var}
 	{/block}
 {/foreach}

--- a/tests/Latte/contentType.compatibility.phpt
+++ b/tests/Latte/contentType.compatibility.phpt
@@ -176,7 +176,6 @@ test(function () {
 
 
 $latte = new Latte\Engine;
-$latte->setTempDirectory(__DIR__ . '/../tmp/');
 $latte->setLoader(new Latte\Loaders\StringLoader([
 	'ical.latte' => '{contentType text/calendar; charset=utf-8} <>',
 

--- a/tests/Latte/contentType.compatibility.phpt
+++ b/tests/Latte/contentType.compatibility.phpt
@@ -176,6 +176,7 @@ test(function () {
 
 
 $latte = new Latte\Engine;
+$latte->setTempDirectory(__DIR__ . '/../tmp/');
 $latte->setLoader(new Latte\Loaders\StringLoader([
 	'ical.latte' => '{contentType text/calendar; charset=utf-8} <>',
 

--- a/tests/Latte/expected/BlockMacros.defineblock.phtml
+++ b/tests/Latte/expected/BlockMacros.defineblock.phtml
@@ -28,18 +28,19 @@ class Template%a% extends Latte\Runtime\Template
 ?>
 
 <?php
-		$this->renderBlock('test', ['var' => 20] + get_defined_vars(), 'html');
+		$this->renderBlock('test', ['var' => 20] + [], 'html');
 ?>
 
 
 <?php
-		$this->renderBlock('testargs', [1] + get_defined_vars(), 'html');
+		$this->renderBlock('testargs', [1] + [], 'html');
 		return get_defined_vars();
 	}
 
 
 	function blockTest($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?>	This is definition #<?php echo LR\Filters::escapeHtmlText($var) /* line 5 */ ?>
 
@@ -51,6 +52,7 @@ class Template%a% extends Latte\Runtime\Template
 	{
 		extract($this->params);
 		list($var1, $var2) = $_args + [NULL, NULL, ];
+		extract($_args);
 		?>	Variables <?php echo LR\Filters::escapeHtmlText($var1) /* line 11 */ ?>, <?php echo LR\Filters::escapeHtmlText($var2) /* line 11 */ ?>, <?php
 		echo LR\Filters::escapeHtmlText($hello) /* line 11 */ ?>
 

--- a/tests/Latte/expected/BlockMacros.dynamicblock.phtml
+++ b/tests/Latte/expected/BlockMacros.dynamicblock.phtml
@@ -20,7 +20,7 @@ class Template%a% extends Latte\Runtime\Template
 
 <?php
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('static', ['var' => $var,]);
+		$this->renderBlock('static', ['var' => $var, ]);
 ?>
 
 
@@ -29,7 +29,7 @@ class Template%a% extends Latte\Runtime\Template
 		foreach (['dynamic', 'static'] as $name) {
 			$this->checkBlockContentType('html', $name);
 			$this->blockQueue[$name][] = [$this, 'blockName'];
-			$this->renderBlock($name, ['var' => $var,]);
+			$this->renderBlock($name, ['var' => $var, ]);
 ?>
 
 <?php

--- a/tests/Latte/expected/BlockMacros.dynamicblock.phtml
+++ b/tests/Latte/expected/BlockMacros.dynamicblock.phtml
@@ -40,15 +40,15 @@ class Template%a% extends Latte\Runtime\Template
 ?>
 
 <?php
-		$this->renderBlock('dynamic', ['var' => 20] + $this->params, 'html');
+		$this->renderBlock('dynamic', ['var' => 20] + [], 'html');
 ?>
 
 <?php
-		$this->renderBlock('static', ['var' => 30] + get_defined_vars(), 'html');
+		$this->renderBlock('static', ['var' => 30] + [], 'html');
 ?>
 
 <?php
-		$this->renderBlock($name . '', ['var' => 40] + $this->params, 'html');
+		$this->renderBlock($name . '', ['var' => 40] + [], 'html');
 ?>
 
 <?php
@@ -82,6 +82,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockName($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?>		Dynamic block #<?php echo LR\Filters::escapeHtmlText($var) /* line 10 */ ?>
 
@@ -91,6 +92,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockWord_name($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		if (false) {
 			?><div></div><?php
@@ -101,6 +103,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockStrip_name($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?><span>hello</span><?php
 	}
@@ -108,6 +111,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockStatic($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?>	Static block #<?php echo LR\Filters::escapeHtmlText($var) /* line 4 */ ?>
 

--- a/tests/Latte/expected/BlockMacros.dynamicblock.phtml
+++ b/tests/Latte/expected/BlockMacros.dynamicblock.phtml
@@ -20,23 +20,21 @@ class Template%a% extends Latte\Runtime\Template
 
 <?php
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('static', get_defined_vars());
+		$this->renderBlock('static', ['var' => $var,]);
 ?>
 
 
 <?php
 		$iterations = 0;
-		foreach ($iterator = $this->global->its[] = new LR\CachingIterator(['dynamic', 'static']) as $name) {
+		foreach (['dynamic', 'static'] as $name) {
 			$this->checkBlockContentType('html', $name);
 			$this->blockQueue[$name][] = [$this, 'blockName'];
-			$this->renderBlock($name, get_defined_vars());
+			$this->renderBlock($name, ['var' => $var,]);
 ?>
 
 <?php
 			$iterations++;
 		}
-		array_pop($this->global->its);
-		$iterator = end($this->global->its);
 ?>
 
 <?php
@@ -54,14 +52,14 @@ class Template%a% extends Latte\Runtime\Template
 <?php
 		$this->checkBlockContentType('html', "word$name");
 		$this->blockQueue["word$name"][] = [$this, 'blockWord_name'];
-		$this->renderBlock("word$name", get_defined_vars());
+		$this->renderBlock("word$name", []);
 ?>
 
 
 <?php
 		$this->checkBlockContentType('html', "strip$name");
 		$this->blockQueue["strip$name"][] = [$this, 'blockStrip_name'];
-		$this->renderBlock("strip$name", get_defined_vars(), function ($s, $type) {
+		$this->renderBlock("strip$name", [], function ($s, $type) {
 			$_fi = new LR\FilterInfo($type);
 			return LR\Filters::convertTo($_fi, 'html', $this->filters->filterContent('striptags', $_fi, $s));
 		});
@@ -112,6 +110,7 @@ class Template%a% extends Latte\Runtime\Template
 	function blockStatic($_args)
 	{
 		extract($this->params);
+		list($var) = $_args + [NULL, ];
 		extract($_args);
 		?>	Static block #<?php echo LR\Filters::escapeHtmlText($var) /* line 4 */ ?>
 

--- a/tests/Latte/expected/BlockMacros.import.phtml
+++ b/tests/Latte/expected/BlockMacros.import.phtml
@@ -7,7 +7,7 @@ class Template%a% extends Latte\Runtime\Template
 	function main()
 	{
 %A%
-		$this->renderBlock('test', $this->params, 'html');
+		$this->renderBlock('test', [], 'html');
 		?>	<?php
 %A%
 	}

--- a/tests/Latte/expected/BlockMacros.includeblock.inc.phtml
+++ b/tests/Latte/expected/BlockMacros.includeblock.inc.phtml
@@ -26,6 +26,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockTest($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?>	Parent: <?php echo LR\Filters::escapeHtmlText(basename($this->getReferringTemplate()->getName())) /* line 3 */ ?>/<?php
 		echo LR\Filters::escapeHtmlText($this->getReferenceType()) /* line 3 */ ?>

--- a/tests/Latte/expected/BlockMacros.includeblock.phtml
+++ b/tests/Latte/expected/BlockMacros.includeblock.phtml
@@ -8,7 +8,7 @@ class Template%a% extends Latte\Runtime\Template
 	{
 %A%
 		ob_start(function () {});
-		$this->createTemplate("inc", [], "includeblock")->renderToContentType('html');
+		$this->createTemplate("inc", $this->params, "includeblock")->renderToContentType('html');
 		echo rtrim(ob_get_clean());
 ?>
 

--- a/tests/Latte/expected/BlockMacros.includeblock.phtml
+++ b/tests/Latte/expected/BlockMacros.includeblock.phtml
@@ -8,12 +8,12 @@ class Template%a% extends Latte\Runtime\Template
 	{
 %A%
 		ob_start(function () {});
-		$this->createTemplate("inc", get_defined_vars(), "includeblock")->renderToContentType('html');
+		$this->createTemplate("inc", [], "includeblock")->renderToContentType('html');
 		echo rtrim(ob_get_clean());
 ?>
 
 <?php
-		$this->renderBlock('test', $this->params, 'html');
+		$this->renderBlock('test', [], 'html');
 		?>	<?php
 %A%
 	}

--- a/tests/Latte/expected/BlockMacros.inheritance.child1.parent.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child1.parent.phtml
@@ -22,7 +22,7 @@ class Template%a% extends Latte\Runtime\Template
 <head>
 	<title><?php
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('title', get_defined_vars(), function ($s, $type) {
+		$this->renderBlock('title', [], function ($s, $type) {
 			$_fi = new LR\FilterInfo($type);
 			return LR\Filters::convertTo($_fi, 'html', $this->filters->filterContent('upper', $_fi, $this->filters->filterContent('striphtml', $_fi, $s)));
 		});
@@ -32,7 +32,7 @@ class Template%a% extends Latte\Runtime\Template
 <body>
 	<div id="sidebar">
 <?php
-		$this->renderBlock('sidebar', get_defined_vars());
+		$this->renderBlock('sidebar', []);
 ?>
 	</div>
 

--- a/tests/Latte/expected/BlockMacros.inheritance.child1.parent.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child1.parent.phtml
@@ -38,11 +38,11 @@ class Template%a% extends Latte\Runtime\Template
 
 	<div id="content">
 <?php
-		$this->renderBlock('content', $this->params, 'html');
+		$this->renderBlock('content', [], 'html');
 ?>
 
 <?php
-		$this->renderBlock('content', $this->params, function ($s, $type) {
+		$this->renderBlock('content', [], function ($s, $type) {
 			$_fi = new LR\FilterInfo($type);
 			return LR\Filters::convertTo($_fi, 'html', $this->filters->filterContent('upper', $_fi, $this->filters->filterContent('striphtml', $_fi, $s)));
 		});

--- a/tests/Latte/expected/BlockMacros.inheritance.child1.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child1.phtml
@@ -18,17 +18,17 @@ class Template%a% extends Latte\Runtime\Template
 	{
 %A%
 		ob_start(function () {});
-		$this->createTemplate("inc", [], "includeblock")->renderToContentType('html');
+		$this->createTemplate("inc", $this->params, "includeblock")->renderToContentType('html');
 		echo rtrim(ob_get_clean());
 ?>
 
 <?php
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('title', get_defined_vars());
+		$this->renderBlock('title', []);
 ?>
 
 <?php
-		$this->renderBlock('content', get_defined_vars());
+		$this->renderBlock('content', []);
 		?>	<?php
 %A%
 	}

--- a/tests/Latte/expected/BlockMacros.inheritance.child1.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child1.phtml
@@ -18,7 +18,7 @@ class Template%a% extends Latte\Runtime\Template
 	{
 %A%
 		ob_start(function () {});
-		$this->createTemplate("inc", get_defined_vars(), "includeblock")->renderToContentType('html');
+		$this->createTemplate("inc", [], "includeblock")->renderToContentType('html');
 		echo rtrim(ob_get_clean());
 ?>
 
@@ -46,16 +46,18 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockTitle($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?>Homepage | <?php
-		$this->renderBlockParent('title', get_defined_vars());
-		$this->renderBlockParent('title', get_defined_vars());
+		$this->renderBlockParent('title', $_args);
+		$this->renderBlockParent('title', $_args);
 
 	}
 
 
 	function blockContent($_args)
 	{
+		extract($this->params);
 		extract($_args);
 ?>
 	<ul>

--- a/tests/Latte/expected/BlockMacros.inheritance.child2.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child2.phtml
@@ -21,11 +21,11 @@ class Template%a% extends Latte\Runtime\Template
 %A%
 <?php
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('content', get_defined_vars());
+		$this->renderBlock('content', []);
 ?>
 
 <?php
-		$this->renderBlock('sidebar', get_defined_vars());
+		$this->renderBlock('sidebar', []);
 		?>	<?php
 %A%
 	}
@@ -45,7 +45,7 @@ class Template%a% extends Latte\Runtime\Template
 		extract($this->params);
 		extract($_args);
 		?>	<h1><?php
-		$this->renderBlock('title', get_defined_vars());
+		$this->renderBlock('title', []);
 ?></h1>
 
 	<ul>

--- a/tests/Latte/expected/BlockMacros.inheritance.child2.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child2.phtml
@@ -42,6 +42,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockContent($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?>	<h1><?php
 		$this->renderBlock('title', get_defined_vars());

--- a/tests/Latte/expected/BlockMacros.inheritance.child5.phtml
+++ b/tests/Latte/expected/BlockMacros.inheritance.child5.phtml
@@ -17,7 +17,7 @@ class Template%a% extends Latte\Runtime\Template
 %A%
 <?php
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('content', get_defined_vars());
+		$this->renderBlock('content', []);
 		?>	<?php
 %A%
 	}

--- a/tests/Latte/expected/BlockMacros.snippet.block.phtml
+++ b/tests/Latte/expected/BlockMacros.snippet.block.phtml
@@ -25,16 +25,17 @@ class Template%a% extends Latte\Runtime\Template
 ?>
 
 
-<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer')) ?>"><?php $this->renderBlock('_outer', $this->params) ?></div><?php
+<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer')) ?>"><?php $this->renderBlock('_outer', []) ?></div><?php
 %A%
 	}
 
 
 	function blockBlock1($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?><div<?php echo ' id="' . htmlSpecialChars($this->global->snippetDriver->getHtmlId('snippet')) . '"' ?>>
-<?php $this->renderBlock('_snippet', $this->params) ?>
+<?php $this->renderBlock('_snippet', []) ?>
 </div>
 <?php
 
@@ -43,6 +44,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockSnippet($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("snippet", "static");
 ?>		static
@@ -54,6 +56,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockOuter($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("outer", "static");
 ?>
@@ -70,6 +73,7 @@ end
 
 	function blockBlock2($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		?><div<?php echo ' id="' . htmlSpecialChars($this->global->snippetDriver->getHtmlId("inner-$id")) . '"' ?>>
 <?php

--- a/tests/Latte/expected/BlockMacros.snippet.block.phtml
+++ b/tests/Latte/expected/BlockMacros.snippet.block.phtml
@@ -21,7 +21,7 @@ class Template%a% extends Latte\Runtime\Template
 	function main()
 	{
 %A%
-		$this->renderBlock('block1', get_defined_vars());
+		$this->renderBlock('block1', []);
 ?>
 
 
@@ -62,7 +62,7 @@ class Template%a% extends Latte\Runtime\Template
 ?>
 begin
 <?php
-		$this->renderBlock('block2', get_defined_vars());
+		$this->renderBlock('block2', []);
 ?>
 end
 <?php

--- a/tests/Latte/expected/BlockMacros.snippet.dynamic.alt.phtml
+++ b/tests/Latte/expected/BlockMacros.snippet.dynamic.alt.phtml
@@ -17,9 +17,9 @@ class Template%a% extends Latte\Runtime\Template
 	function main()
 	{
 %A%
-		?><div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer1')) ?>"><?php $this->renderBlock('_outer1', $this->params) ?></div>
+		?><div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer1')) ?>"><?php $this->renderBlock('_outer1', []) ?></div>
 
-<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer2')) ?>"><?php $this->renderBlock('_outer2', $this->params) ?></div><?php
+<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer2')) ?>"><?php $this->renderBlock('_outer2', []) ?></div><?php
 %A%
 	}
 
@@ -32,6 +32,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockOuter1($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("outer1", "static");
 		$iterations = 0;
@@ -54,6 +55,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockOuter2($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("outer2", "static");
 		$iterations = 0;

--- a/tests/Latte/expected/BlockMacros.snippet.dynamic.phtml
+++ b/tests/Latte/expected/BlockMacros.snippet.dynamic.phtml
@@ -15,7 +15,7 @@ class Template%a% extends Latte\Runtime\Template
 	function main()
 	{
 %A%
-		?><div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer')) ?>"><?php $this->renderBlock('_outer', $this->params) ?></div><?php
+		?><div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer')) ?>"><?php $this->renderBlock('_outer', []) ?></div><?php
 %A%
 	}
 
@@ -28,6 +28,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockOuter($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("outer", "static");
 		$iterations = 0;

--- a/tests/Latte/expected/BlockMacros.snippet.n.phtml
+++ b/tests/Latte/expected/BlockMacros.snippet.n.phtml
@@ -20,16 +20,16 @@ class Template%a% extends Latte\Runtime\Template
 	{
 %A%
 		?>	<div class="test"<?php echo ' id="' . htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer')) . '"' ?>>
-<?php $this->renderBlock('_outer', $this->params) ?>
+<?php $this->renderBlock('_outer', []) ?>
 	</div>
 
 	<div class="test"<?php echo ' id="' . htmlSpecialChars($this->global->snippetDriver->getHtmlId('inner')) . '"' ?>>
 <?php
-		$this->renderBlock('_inner', $this->params);
+		$this->renderBlock('_inner', []);
 ?>	</div>
 
 	<div class="<?php echo LR\Filters::escapeHtmlAttr('class') /* line 9 */ ?>"<?php echo ' id="' . htmlSpecialChars($this->global->snippetDriver->getHtmlId('gallery')) . '"' ?>><?php
-		$this->renderBlock('_gallery', $this->params) ?>
+		$this->renderBlock('_gallery', []) ?>
 </div>
 <?php
 %A%
@@ -38,6 +38,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockOuter($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("outer", "static");
 ?>	<p>Outer</p>
@@ -49,6 +50,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockInner($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("inner", "static");
 ?>	<p>Inner</p>
@@ -60,6 +62,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockGallery($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("gallery", "static");
 		$this->global->snippetDriver->leave();

--- a/tests/Latte/expected/BlockMacros.snippet.phtml
+++ b/tests/Latte/expected/BlockMacros.snippet.phtml
@@ -23,10 +23,10 @@ class Template%a% extends Latte\Runtime\Template
 	function main()
 	{
 %A%
-		?><div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('')) ?>"><?php $this->renderBlock('_', $this->params) ?></div>
+		?><div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('')) ?>"><?php $this->renderBlock('_', []) ?></div>
 
 
-<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer')) ?>"><?php $this->renderBlock('_outer', $this->params) ?></div>
+<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('outer')) ?>"><?php $this->renderBlock('_outer', []) ?></div>
 
 
 	@<?php
@@ -36,14 +36,15 @@ class Template%a% extends Latte\Runtime\Template
 ?>
 
 
-	<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('title')) ?>"><?php $this->renderBlock('_title', $this->params) ?></div>
-	<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('title2')) ?>"><?php $this->renderBlock('_title2', $this->params) ?></div><?php
+	<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('title')) ?>"><?php $this->renderBlock('_title', []) ?></div>
+	<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('title2')) ?>"><?php $this->renderBlock('_title2', []) ?></div><?php
 		return get_defined_vars();
 	}
 
 
 	function block_%h%($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("", "static");
 ?>
@@ -56,11 +57,12 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockOuter($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("outer", "static");
 ?>
 	Outer
-		<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('inner')) ?>"><?php $this->renderBlock('_inner', $this->params) ?></div>	/Outer
+		<div id="<?php echo htmlSpecialChars($this->global->snippetDriver->getHtmlId('inner')) ?>"><?php $this->renderBlock('_inner', []) ?></div>	/Outer
 <?php
 		$this->global->snippetDriver->leave();
 
@@ -69,6 +71,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockInner($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("inner", "static");
 		?>Inner<?php
@@ -79,6 +82,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockTitle($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("title", "static");
 		?>Title 1<?php
@@ -89,6 +93,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockTitle2($_args)
 	{
+		extract($this->params);
 		extract($_args);
 		$this->global->snippetDriver->enter("title2", "static");
 		?>Title 2<?php

--- a/tests/Latte/expected/macros.general.html.phtml
+++ b/tests/Latte/expected/macros.general.html.phtml
@@ -160,7 +160,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 <?php
 		$counter = 0;
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('menu', ['counter' => $counter,]);
+		$this->renderBlock('menu', ['counter' => $counter, ]);
 ?>
 
 

--- a/tests/Latte/expected/macros.general.html.phtml
+++ b/tests/Latte/expected/macros.general.html.phtml
@@ -265,16 +265,17 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 
 	function blockMenu($_args)
 	{
+		extract($this->params);
 		extract($_args);
 ?>
 <ul>
 <?php
 		$iterations = 0;
-		foreach ($iterator = $this->global->its[] = new LR\CachingIterator($menu) as $item) {
+		foreach ($menu as $item) {
 			?>	<li><?php echo LR\Filters::escapeHtmlText($counter++) /* line 105 */ ?> <?php
 			if (is_array($item)) {
 				?> <?php
-				$this->renderBlock('menu', ['menu' => $item] + get_defined_vars(), 'html');
+				$this->renderBlock('menu', ['menu' => $item, 'counter' => $counter] + [], 'html');
 				?> <?php
 			}
 			else {
@@ -284,8 +285,6 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 <?php
 			$iterations++;
 		}
-		array_pop($this->global->its);
-		$iterator = end($this->global->its);
 ?>
 </ul>
 <?php

--- a/tests/Latte/expected/macros.general.html.phtml
+++ b/tests/Latte/expected/macros.general.html.phtml
@@ -160,7 +160,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 <?php
 		$counter = 0;
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('menu', get_defined_vars());
+		$this->renderBlock('menu', ['counter' => $counter,]);
 ?>
 
 
@@ -266,6 +266,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 	function blockMenu($_args)
 	{
 		extract($this->params);
+		list($counter) = $_args + [NULL, ];
 		extract($_args);
 ?>
 <ul>
@@ -275,7 +276,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 			?>	<li><?php echo LR\Filters::escapeHtmlText($counter++) /* line 105 */ ?> <?php
 			if (is_array($item)) {
 				?> <?php
-				$this->renderBlock('menu', ['menu' => $item, 'counter' => $counter] + [], 'html');
+				$this->renderBlock('menu', [$counter, 'menu' => $item] + [], 'html');
 				?> <?php
 			}
 			else {

--- a/tests/Latte/expected/macros.general.xhtml.phtml
+++ b/tests/Latte/expected/macros.general.xhtml.phtml
@@ -162,7 +162,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 <?php
 		$counter = 0;
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('menu', get_defined_vars());
+		$this->renderBlock('menu', ['counter' => $counter,]);
 ?>
 
 
@@ -268,6 +268,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 	function blockMenu($_args)
 	{
 		extract($this->params);
+		list($counter) = $_args + [NULL, ];
 		extract($_args);
 ?>
 <ul>
@@ -277,7 +278,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 			?>	<li><?php echo LR\Filters::escapeHtmlText($counter++) /* line 105 */ ?> <?php
 			if (is_array($item)) {
 				?> <?php
-				$this->renderBlock('menu', ['menu' => $item, 'counter' => $counter] + [], 'xhtml');
+				$this->renderBlock('menu', [$counter, 'menu' => $item] + [], 'xhtml');
 				?> <?php
 			}
 			else {

--- a/tests/Latte/expected/macros.general.xhtml.phtml
+++ b/tests/Latte/expected/macros.general.xhtml.phtml
@@ -162,7 +162,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 <?php
 		$counter = 0;
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('menu', ['counter' => $counter,]);
+		$this->renderBlock('menu', ['counter' => $counter, ]);
 ?>
 
 

--- a/tests/Latte/expected/macros.general.xhtml.phtml
+++ b/tests/Latte/expected/macros.general.xhtml.phtml
@@ -267,16 +267,17 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 
 	function blockMenu($_args)
 	{
+		extract($this->params);
 		extract($_args);
 ?>
 <ul>
 <?php
 		$iterations = 0;
-		foreach ($iterator = $this->global->its[] = new LR\CachingIterator($menu) as $item) {
+		foreach ($menu as $item) {
 			?>	<li><?php echo LR\Filters::escapeHtmlText($counter++) /* line 105 */ ?> <?php
 			if (is_array($item)) {
 				?> <?php
-				$this->renderBlock('menu', ['menu' => $item] + get_defined_vars(), 'xhtml');
+				$this->renderBlock('menu', ['menu' => $item, 'counter' => $counter] + [], 'xhtml');
 				?> <?php
 			}
 			else {
@@ -286,8 +287,6 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
 <?php
 			$iterations++;
 		}
-		array_pop($this->global->its);
-		$iterator = end($this->global->its);
 ?>
 </ul>
 <?php

--- a/tests/Latte/expected/macros.n-macros.phtml
+++ b/tests/Latte/expected/macros.n-macros.phtml
@@ -373,6 +373,7 @@ class Template%a% extends Latte\Runtime\Template
 
 	function blockBl($_args)
 	{
+		extract($this->params);
 		extract($_args);
 ?><ul title="block + if + foreach">
 <?php

--- a/tests/Latte/expected/macros.n-macros.phtml
+++ b/tests/Latte/expected/macros.n-macros.phtml
@@ -57,7 +57,7 @@ class Template%a% extends Latte\Runtime\Template
 
 <?php
 		if ($this->getParentName()) return get_defined_vars();
-		$this->renderBlock('bl', get_defined_vars());
+		$this->renderBlock('bl', []);
 ?>
 
 

--- a/tests/Latte/templates/general.latte
+++ b/tests/Latte/templates/general.latte
@@ -99,10 +99,10 @@ var prop2 = {$people};
 
 
 {var $counter = 0}
-{block menu}
+{block menu $counter}
 <ul>
 	{foreach $menu as $item}
-	<li>{$counter++} {if is_array($item)} {include this, 'menu' => $item, 'counter' => $counter} {else}{$item}{/if}</li>
+	<li>{$counter++} {if is_array($item)} {include this, $counter, 'menu' => $item} {else}{$item}{/if}</li>
 	{/foreach}
 </ul>
 {/block}

--- a/tests/Latte/templates/general.latte
+++ b/tests/Latte/templates/general.latte
@@ -102,7 +102,7 @@ var prop2 = {$people};
 {block menu}
 <ul>
 	{foreach $menu as $item}
-	<li>{$counter++} {if is_array($item)} {include this, 'menu' => $item} {else}{$item}{/if}</li>
+	<li>{$counter++} {if is_array($item)} {include this, 'menu' => $item, 'counter' => $counter} {else}{$item}{/if}</li>
 	{/foreach}
 </ul>
 {/block}


### PR DESCRIPTION
- BC break? yes

Latte is a bit inconsistent how it passes variables to blocks (get_defined_vars vs this->params). Mostly it is "just" a confusing feature, but sometimes it is a bug.

This PR unifies the behavior that only variables from this->params are implicitly available. 

It is done by passing nothing to renderBlock and instead `extract($this->params)` is called in each block. This approach allows future feature to have different parameters for main template and layout. (because it extracts parameters of own Template object)

Of course, there are some BC breaks - mainly that you have to explicitly name parameters you want in a block from the outer scope.

So instead of
```latte
{var $foo = 1}
{block bar}
{$foo}
{/block}
```
you have to write
```latte
{var $foo = 1}
{block bar $foo}
{$foo}
{/block}
```

what do you think about it? 

cc @JanTvrdik