### PR TITLE
Show template path

### DIFF
--- a/src/Latte/Loaders/FileLoader.php
+++ b/src/Latte/Loaders/FileLoader.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Latte\Loaders;
 
 use Latte;
+use Tracy\Debugger;
 
 
 /**
@@ -46,7 +47,14 @@ class FileLoader implements Latte\ILoader
 				trigger_error("File's modification time is in the future. Cannot update it: " . error_get_last()['message'], E_USER_WARNING);
 			}
 		}
-		return file_get_contents($file);
+
+		$fileContent = file_get_contents($file);
+		if (Debugger::isEnabled()) {
+			$commentPath = realpath($file);
+			return "\n<!-- Start: " . $commentPath . " -->\n" . $fileContent . "\n<!-- End: " . $commentPath . " -->\n";
+		}
+
+		return $fileContent;
 	}
 
 


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? yes 

This commit add HTML comment to rendered template with path of template file.
It's very usefull when developer is fixing bugs in someone else code.
Current implementation is naive and easy - use Tracy Debugger's method isEnabled for enabling.
It also doesn't have context, so it can potentially break included JS/CSS. We can discuss better and more clean solution.