### PR TITLE
[2.4] Hotfix - `isExpired` correct file path

### DIFF
--- a/src/Latte/Loaders/FileLoader.php
+++ b/src/Latte/Loaders/FileLoader.php
@@ -31,16 +31,16 @@ class FileLoader implements Latte\ILoader
 	 * Returns template source code.
 	 * @return string
 	 */
-	public function getContent($file)
+	public function getContent($fileName)
 	{
-		$file = $this->baseDir . $file;
+		$file = $this->baseDir . $fileName;
 		if ($this->baseDir && !Latte\Helpers::startsWith($this->normalizePath($file), $this->baseDir)) {
 			throw new \RuntimeException("Template '$file' is not within the allowed path '$this->baseDir'.");
 
 		} elseif (!is_file($file)) {
 			throw new \RuntimeException("Missing template file '$file'.");
 
-		} elseif ($this->isExpired($file, time())) {
+		} elseif ($this->isExpired($fileName, time())) {
 			if (@touch($file) === false) {
 				trigger_error("File's modification time is in the future. Cannot update it: " . error_get_last()['message'], E_USER_WARNING);
 			}


### PR DESCRIPTION
Method was called from `getContent` with the full file path (see lines 36 and 43) and inside the method `isExpired` baseDir was added another time (see line 57), so as the result we have: "baseDir/baseDir/fileName.ext"

https://github.com/nette/latte/blob/e6ab6ccc5c372036b99bf8b03c2b6ff9f1cec621/src/Latte/Loaders/FileLoader.php#L34-L43

https://github.com/nette/latte/blob/e6ab6ccc5c372036b99bf8b03c2b6ff9f1cec621/src/Latte/Loaders/FileLoader.php#L55-L57


Fix for *2.4* branch, but it should be also fixed on master.

- bug fix? yes/~no~   <!-- #issue numbers, if any -->
- new feature? ~yes~/no
- BC break? ~yes~/no
- doc PR: ~nette/docs#???~  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
