### PR TITLE
added CachingIterator::__toString()

### DIFF
--- a/src/Latte/Runtime/CachingIterator.php
+++ b/src/Latte/Runtime/CachingIterator.php
@@ -112,6 +112,15 @@ class CachingIterator extends \CachingIterator implements \Countable
 
 
 	/**
+	 * Returns the counter as string
+	 */
+	public function __toString(): string
+	{
+		return (string) $this->counter;
+	}
+
+
+	/**
 	 * Returns the count of elements.
 	 */
 	public function count(): int

--- a/tests/Latte/CachingIterator.basic.phpt
+++ b/tests/Latte/CachingIterator.basic.phpt
@@ -23,6 +23,7 @@ test(function () { // ==> Two items in array
 	Assert::true($iterator->isFirst());
 	Assert::false($iterator->isLast());
 	Assert::same(1, $iterator->getCounter());
+	Assert::same('1', (string) $iterator);
 
 	$iterator->next();
 	Assert::true($iterator->valid());


### PR DESCRIPTION
When an iterator has been used in a template just as `{$iterator}` and not
as `{$iterator->counter}` (as documented), it has thrown a kind of confusing
error:

  Fatal error: Method Latte\Runtime\CachingIterator::__toString() must not
  throw an exception, caught BadMethodCallException: Latte\Runtime\CachingIterator
  does not fetch string value (see CachingIterator::__construct) in *PATH* on line 0

This patch allows conversion to a string by returning the current counter.

- bug fix? yes
- BC break? no

