### PR TITLE
Allow to have no macros in Compiler

### DIFF
--- a/src/Latte/Compiler/Compiler.php
+++ b/src/Latte/Compiler/Compiler.php
@@ -55,7 +55,7 @@ class Compiler
 	private $position;
 
 	/** @var array of [name => IMacro[]] */
-	private $macros;
+	private $macros = [];
 
 	/** @var int[] IMacro flags */
 	private $flags;
@@ -124,7 +124,10 @@ class Compiler
 		$this->methods = ['main' => null, 'prepare' => null];
 
 		$macroHandlers = new \SplObjectStorage;
-		array_map([$macroHandlers, 'attach'], call_user_func_array('array_merge', $this->macros));
+
+		if ($this->macros) {
+			array_map([$macroHandlers, 'attach'], call_user_func_array('array_merge', $this->macros));
+		}
 
 		foreach ($macroHandlers as $handler) {
 			$handler->initialize($this);

--- a/tests/Latte/Compiler.emptyMacros.phpt
+++ b/tests/Latte/Compiler.emptyMacros.phpt
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Test: Empty macros.
+ */
+
+use Latte\Compiler;
+use Latte\Engine;
+use Latte\Loaders\StringLoader;
+use Latte\MacroNode;
+use Latte\Macros\MacroSet;
+use Latte\PhpWriter;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+class EnhancedEngine extends Engine
+{
+	private $compiler;
+
+
+	public function getCompiler()
+	{
+		if (!$this->compiler) {
+			$this->compiler = new Compiler();
+		}
+
+		return $this->compiler;
+	}
+}
+
+// With no macros
+test(function () {
+	$latte = new EnhancedEngine();
+	$latte->setLoader(new StringLoader);
+	Assert::equal('foo', $latte->renderToString('foo'));
+});
+
+// With {=} macro
+test(function () {
+	$latte = new EnhancedEngine();
+	$latte->setLoader(new StringLoader);
+	$set = new MacroSet($latte->getCompiler());
+	$set->addMacro('=', function (MacroNode $node, PhpWriter $writer) {
+		return $writer->write('echo %modify(%node.args)');
+	});
+
+	Assert::equal('bar', $latte->renderToString('{$foo}', ['foo' => 'bar']));
+	Assert::equal('bar', $latte->renderToString('{=$foo}', ['foo' => 'bar']));
+});


### PR DESCRIPTION
- bug fix: #176 
- BC break? no
- doc PR: no needed

This PR has 2 changes:
- upgrade nette/tester to v2.0
- allow to use own Compiler with no defined macros