### PR TITLE
Allow custom Template implementation

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -89,7 +89,7 @@ class Engine
 	/**
 	 * Creates template object.
 	 */
-	public function createTemplate(string $name, array $params = []): Runtime\Template
+	public function createTemplate(string $name, array $params = []): Runtime\ITemplate
 	{
 		$class = $this->getTemplateClass($name);
 		if (!class_exists($class, false)) {

--- a/src/Latte/Helpers.php
+++ b/src/Latte/Helpers.php
@@ -35,6 +35,17 @@ class Helpers
 	}
 
 
+	public static function composeUseNamespaces(array $namespaces): string
+	{
+		$useLines = [];
+		foreach ($namespaces as $namespace => $alias) {
+			$useLines[] .= "use $namespace as $alias;";
+		}
+
+		return implode("\n", $useLines);
+	}
+
+
 	/**
 	 * Finds the best suggestion.
 	 */

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -12,9 +12,11 @@ namespace Latte\Macros;
 use Latte;
 use Latte\CompileException;
 use Latte\Helpers;
+use Latte\ImplementationException;
 use Latte\MacroNode;
 use Latte\PhpWriter;
 use Latte\Runtime\SnippetDriver;
+use Latte\Runtime\Template;
 
 
 /**
@@ -38,6 +40,16 @@ class BlockMacros extends MacroSet
 	public static function install(Latte\Compiler $compiler): void
 	{
 		$me = new static($compiler);
+
+		if (
+			$compiler->getTemplateCLass() !== Template::class &&
+			!in_array(Template::class, class_parents($compiler->getTemplateCLass()), true)
+		) {
+			throw new ImplementationException(
+				'BlockMacros need ' . $compiler->getTemplateCLass() . ' to inherit from ' . Template::class
+			);
+		}
+
 		$me->addMacro('include', [$me, 'macroInclude']);
 		$me->addMacro('includeblock', [$me, 'macroIncludeBlock']); // deprecated
 		$me->addMacro('import', [$me, 'macroImport'], null, null, self::ALLOWED_IN_HEAD);

--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -13,8 +13,10 @@ use Latte;
 use Latte\CompileException;
 use Latte\Engine;
 use Latte\Helpers;
+use Latte\ImplementationException;
 use Latte\MacroNode;
 use Latte\PhpWriter;
+use Latte\Runtime\Template;
 
 
 /**
@@ -46,6 +48,15 @@ class CoreMacros extends MacroSet
 	public static function install(Latte\Compiler $compiler): void
 	{
 		$me = new static($compiler);
+
+		if (
+			$compiler->getTemplateCLass() !== Template::class &&
+			!in_array(Template::class, class_parents($compiler->getTemplateCLass()), true)
+		) {
+			throw new ImplementationException(
+				'CoreMacros need ' . $compiler->getTemplateCLass() . ' to inherit from ' . Template::class
+			);
+		}
 
 		$me->addMacro('if', [$me, 'macroIf'], [$me, 'macroEndIf']);
 		$me->addMacro('elseif', '} elseif (%node.args) {');

--- a/src/Latte/Runtime/ITemplate.php
+++ b/src/Latte/Runtime/ITemplate.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This file is part of the Latte (https://latte.nette.org)
+ * Copyright (c) 2008 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Latte\Runtime;
+
+
+interface ITemplate
+{
+	public function render(): void;
+}

--- a/src/Latte/Runtime/Template.php
+++ b/src/Latte/Runtime/Template.php
@@ -16,9 +16,14 @@ use Latte\Engine;
 /**
  * Template.
  */
-class Template
+class Template implements ITemplate
 {
 	use Latte\Strict;
+
+	/** @var [className => alias] namespaces required for the correct functioning of child classes */
+	public const USE_NAMESPACES = [
+		'Latte\Runtime' => 'LR',
+	];
 
 	/** @var \stdClass global accumulators for intermediate results */
 	public $global;

--- a/src/Latte/exceptions.php
+++ b/src/Latte/exceptions.php
@@ -62,6 +62,14 @@ class RegexpException extends \Exception
 
 
 /**
+ * The exception that indicates passing class, which doesn't implement proper interface.
+ */
+class ImplementationException extends \Exception
+{
+}
+
+
+/**
  * The exception that indicates error during rendering template.
  */
 class RuntimeException extends \Exception

--- a/src/latte.php
+++ b/src/latte.php
@@ -29,6 +29,7 @@ spl_autoload_register(function ($className) {
 		Latte\Runtime\Html::class => 'Runtime/Html.php',
 		Latte\Runtime\IHtmlString::class => 'Runtime/IHtmlString.php',
 		Latte\Runtime\ISnippetBridge::class => 'Runtime/ISnippetBridge.php',
+		Latte\Runtime\ITemplate::class => 'Runtime/ITemplate.php',
 		Latte\Runtime\SnippetDriver::class => 'Runtime/SnippetDriver.php',
 		Latte\Runtime\Template::class => 'Runtime/Template.php',
 		Latte\RuntimeException::class => 'exceptions.php',

--- a/tests/Latte/Compiler.templateClass.phpt
+++ b/tests/Latte/Compiler.templateClass.phpt
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Test: templateClass
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+final class CustomTemplate implements Latte\Runtime\ITemplate
+{
+	public const USE_NAMESPACES = [
+		'Latte\Runtime' => 'LR',
+	];
+
+
+	public function render(): void
+	{
+	}
+}
+
+
+final class InheritedTemplate extends Latte\Runtime\Template
+{
+}
+
+
+final class BadTemplate
+{
+}
+
+
+$compiler = new Latte\Compiler;
+$parser = new Latte\Parser;
+$tokens = $parser->parse('Custom Template');
+
+$compiler->setTemplateClass(CustomTemplate::class);
+$classBody = $compiler->compile($tokens, 'CustomTemplateChild');
+
+Assert::same('<?php
+use Latte\Runtime as LR;
+
+class CustomTemplateChild extends CustomTemplate
+{
+
+	function main()
+	{
+		extract($this->params);?>
+Custom Template<?php return get_defined_vars();
+	}
+
+}
+', $classBody);
+
+Assert::exception(
+	function () use ($compiler) {
+		$compiler->setTemplateClass(BadTemplate::class);
+	},
+	Latte\ImplementationException::class,
+	"Class 'BadTemplate' must implement '" . Latte\Runtime\ITemplate::class . "' interface"
+);
+
+Assert::exception(
+	function () use ($compiler) {
+		Latte\Macros\CoreMacros::install($compiler);
+	},
+	Latte\ImplementationException::class,
+	'CoreMacros need ' . $compiler->getTemplateCLass() . ' to inherit from ' . Latte\Runtime\Template::class
+);
+
+Assert::exception(
+	function () use ($compiler) {
+		Latte\Macros\BlockMacros::install($compiler);
+	},
+	Latte\ImplementationException::class,
+	'BlockMacros need ' . $compiler->getTemplateCLass() . ' to inherit from ' . Latte\Runtime\Template::class
+);
+
+$compiler->setTemplateClass(InheritedTemplate::class);
+Latte\Macros\CoreMacros::install($compiler);
+Latte\Macros\BlockMacros::install($compiler);
+$classBody = $compiler->compile($tokens, 'CustomTemplateChild');
+Assert::same('<?php
+use Latte\Runtime as LR;
+
+class CustomTemplateChild extends InheritedTemplate
+{
+
+	function main()
+	{
+		extract($this->params);?>
+Custom Template<?php return get_defined_vars();
+	}
+
+}
+', $classBody);


### PR DESCRIPTION
- new feature
- BC break? no

I'd like to use Latte as base for custom templating engine, but I was unable to move on without copying and editing classes from Latte. For example:
* Can't add rewritten `CachingIterator` to `Template` use statements, because `use` macro was removed and `Compiler` adds use statements as text.