### PR TITLE
improved file existence checking; use braced vars in strings

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -215,7 +215,7 @@ class Engine
 			? preg_replace('#[^\w@.-]+#', '-', substr($m[0], 1)) . '--'
 			: '';
 		$file = "{$this->tempDirectory}/{$base}{$hash}.php";
-		return file_exists($file) ? $file : false;
+		return file_exists($file) ? $file : '';
 	}
 
 


### PR DESCRIPTION
Improved file existence checking; use braced vars in strings for improved readability.

- bug fix / new feature?   <!-- #issue numbers, if any -->
- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--

1) Use file_exists() instead of @ silence operator, which still issues errors in certain enviro setups.
2) In strings, wrapping variables in braces makes them easier to read, and actually has an ever-so-slight performance bump since PHP does not have to guess, although this is negligible. The readability takes the cake for this one.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->