### PR TITLE
Fixed  override in include macro

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"nette/utils": "to use filter |webalize"
 	},
 	"conflict": {
-		"nette/application": "<2.4.1"
+		"nette/application": "<3.0"
 	},
 	"autoload": {
 		"classmap": ["src/"]

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 	"minimum-stability": "dev",
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.5-dev"
+			"dev-master": "3.0-dev"
 		}
 	}
 }

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -17,7 +17,7 @@ class Engine
 {
 	use Strict;
 
-	public const VERSION = '2.5.2';
+	public const VERSION = '3.0-dev';
 
 	/** Content types */
 	public const

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -356,7 +356,11 @@ class BlockMacros extends MacroSet
 			}
 			if (empty($node->data->leave)) {
 				if (preg_match('#\$|n:#', $node->content)) {
-					$node->content = '<?php extract($_args);' . ($node->data->args ?? '') . ' ?>' . $node->content;
+                    $node->content =
+                        '<?php 
+				            if (isset($_args["_args"])) $_args["_args"] = array_merge($_args["_args"],$_args); 
+				            extract($_args);' . ($node->data->args ?? '') .
+                        ' ?>' . $node->content;
 				}
 				$this->namedBlocks[$node->data->name] = $tmp = preg_replace('#^\n+|(?<=\n)[ \t]+$#D', '', $node->content);
 				$node->content = substr_replace($node->content, $node->openingCode . "\n", strspn($node->content, "\n"), strlen($tmp));

--- a/src/Latte/Macros/BlockMacros.php
+++ b/src/Latte/Macros/BlockMacros.php
@@ -268,6 +268,9 @@ class BlockMacros extends MacroSet
 				return "\$this->checkBlockContentType($blockType, $fname);"
 					. "\$this->blockQueue[$fname][] = [\$this, '{$node->data->func}'];";
 			}
+
+		} elseif ($name[0] === '_') {
+			throw new CompileException("Block name '$name' must not start with an underscore.");
 		}
 
 		// static snippet/snippetArea

--- a/src/Latte/Runtime/ISnippetBridge.php
+++ b/src/Latte/Runtime/ISnippetBridge.php
@@ -16,17 +16,17 @@ namespace Latte\Runtime;
  */
 interface ISnippetBridge
 {
-	function isSnippetMode();
+	function isSnippetMode(): bool;
 
-	function setSnippetMode($snippetMode);
+	function setSnippetMode(bool $snippetMode);
 
-	function needsRedraw($name);
+	function needsRedraw(string $name): bool;
 
-	function markRedrawn($name);
+	function markRedrawn(string $name): void;
 
-	function getHtmlId($name);
+	function getHtmlId(string $name): string;
 
-	function addSnippet($name, $content);
+	function addSnippet(string $name, string $content): void;
 
-	function renderChildren();
+	function renderChildren(): void;
 }

--- a/tests/Latte/BlockMacros.block5.phpt
+++ b/tests/Latte/BlockMacros.block5.phpt
@@ -26,3 +26,7 @@ Assert::match(
 	'<br class="123">',
 	$latte->renderToString('{block test}<br n:class="$var">{/block}', ['var' => 123])
 );
+
+Assert::exception(function () use ($latte) {
+	$latte->renderToString('{define _foobar}Hello{/define}');
+}, Latte\CompileException::class, "Block name '_foobar' must not start with an underscore.");

--- a/tests/Latte/mocks/SnippetBridge.php
+++ b/tests/Latte/mocks/SnippetBridge.php
@@ -18,19 +18,19 @@ class SnippetBridgeMock implements Latte\Runtime\ISnippetBridge
 	}
 
 
-	public function setSnippetMode($snippetMode)
+	public function setSnippetMode(bool $snippetMode)
 	{
 		$this->snippetMode = $snippetMode;
 	}
 
 
-	public function needsRedraw($name): bool
+	public function needsRedraw(string $name): bool
 	{
 		return $this->invalid === true || isset($this->invalid[$name]);
 	}
 
 
-	public function markRedrawn($name): void
+	public function markRedrawn(string $name): void
 	{
 		if ($this->invalid !== true) {
 			unset($this->invalid[$name]);
@@ -38,13 +38,13 @@ class SnippetBridgeMock implements Latte\Runtime\ISnippetBridge
 	}
 
 
-	public function getHtmlId($name): string
+	public function getHtmlId(string $name): string
 	{
 		return $name;
 	}
 
 
-	public function addSnippet($name, $content): void
+	public function addSnippet(string $name, string $content): void
 	{
 		$this->payload[$name] = $content;
 	}


### PR DESCRIPTION
- fix, [Nette forum thread](https://forum.nette.org/cs/32540-parametry-pri-pouziti-include-jsou-vzdy-null#p206103)

Instead of overriding `$_args` in the due of `extract($_args)` while having `$_args['$_args']` it extends them. 
