### PR TITLE
Fix compatibility with PHP 7.4

### DIFF
--- a/src/Latte/Runtime/FilterExecutor.php
+++ b/src/Latte/Runtime/FilterExecutor.php
@@ -178,7 +178,7 @@ class FilterExecutor
 				? new \ReflectionMethod($callback[0], $callback[1])
 				: new \ReflectionFunction($callback);
 			$this->_static[$name][1] = ($tmp = $ref->getParameters())
-				&& (string) $tmp[0]->getType() === FilterInfo::class;
+				&& $tmp[0]->getType()->getName() === FilterInfo::class;
 		}
 		return $this->_static[$name];
 	}

--- a/src/Latte/Runtime/FilterExecutor.php
+++ b/src/Latte/Runtime/FilterExecutor.php
@@ -178,6 +178,7 @@ class FilterExecutor
 				? new \ReflectionMethod($callback[0], $callback[1])
 				: new \ReflectionFunction($callback);
 			$this->_static[$name][1] = ($tmp = $ref->getParameters())
+				&& $tmp[0]->getType() !== null
 				&& $tmp[0]->getType()->getName() === FilterInfo::class;
 		}
 		return $this->_static[$name];


### PR DESCRIPTION
- bug fix
- BC break? no (function is available since 7.1.0)

Function ReflectionType::__toString() is deprecated, use getName() instead.
