### PR TITLE
Typehint macros

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"nette/utils": "to use filter |webalize"
 	},
 	"conflict": {
-		"nette/application": "<2.4.1"
+		"nette/application": "<3.0"
 	},
 	"autoload": {
 		"classmap": ["src/"]

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.6-dev"
+			"dev-master": "3.0-dev"
 		}
 	}
 }

--- a/src/Latte/Compiler/PhpWriter.php
+++ b/src/Latte/Compiler/PhpWriter.php
@@ -253,32 +253,23 @@ class PhpWriter
 	public function shortTernaryPass(MacroTokens $tokens): MacroTokens
 	{
 		$res = new MacroTokens;
-		$inTernary = $tmp = [];
-		$errors = 0;
+		$inTernary = [];
 		while ($tokens->nextToken()) {
-			if ($tokens->isCurrent('?') && $tokens->isNext() && !$tokens->isNext(':', ',', ')', ']', '|')) {
+			if ($tokens->isCurrent('?') && $tokens->isNext() && !$tokens->isNext(':', ',', ')', ']', '|', '[')) {
 				$inTernary[] = $tokens->depth;
-				$tmp[] = $tokens->isNext('[');
 
 			} elseif ($tokens->isCurrent(':')) {
 				array_pop($inTernary);
-				array_pop($tmp);
 
 			} elseif ($tokens->isCurrent(',', ')', ']', '|') && end($inTernary) === $tokens->depth + $tokens->isCurrent(')', ']')) {
 				$res->append(' : null');
 				array_pop($inTernary);
-				$errors += array_pop($tmp);
 			}
 			$res->append($tokens->currentToken());
 		}
 
 		if ($inTernary) {
-			$errors += array_pop($tmp);
 			$res->append(' : null');
-		}
-		if ($errors) {
-			$tokens->reset();
-			trigger_error('Short ternary operator requires braces around array: ' . $tokens->joinAll(), E_USER_DEPRECATED);
 		}
 		return $res;
 	}

--- a/src/Latte/Compiler/PhpWriter.php
+++ b/src/Latte/Compiler/PhpWriter.php
@@ -295,14 +295,14 @@ class PhpWriter
 
 			do {
 				if ($tokens->nextToken('?')) {
-					if ($tokens->isNext() && (!$tokens->isNext($tokens::T_CHAR) || $tokens->isNext('(', '[', '{', ':', '!', '@'))) {  // is it ternary operator?
+					if ($tokens->isNext() && (!$tokens->isNext($tokens::T_CHAR) || $tokens->isNext('(', '{', ':', '!', '@'))) {  // is it ternary operator?
 						$expr->append($addBraces . ' ?');
 						break;
 					}
 
 					$rescue = [$res->tokens, $expr->tokens, $tokens->position, $addBraces];
 
-					if (!$tokens->isNext('->')) {
+					if (!$tokens->isNext('->', '[')) {
 						$expr->prepend('(');
 						$expr->append(' ?? null)' . $addBraces);
 						break;

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -17,7 +17,7 @@ class Engine
 {
 	use Strict;
 
-	public const VERSION = '2.6.0';
+	public const VERSION = '3.0-dev';
 
 	/** Content types */
 	public const

--- a/src/Latte/Runtime/ISnippetBridge.php
+++ b/src/Latte/Runtime/ISnippetBridge.php
@@ -16,17 +16,17 @@ namespace Latte\Runtime;
  */
 interface ISnippetBridge
 {
-	function isSnippetMode();
+	function isSnippetMode(): bool;
 
-	function setSnippetMode($snippetMode);
+	function setSnippetMode(bool $snippetMode);
 
-	function needsRedraw($name);
+	function needsRedraw(string $name): bool;
 
-	function markRedrawn($name);
+	function markRedrawn(string $name): void;
 
-	function getHtmlId($name);
+	function getHtmlId(string $name): string;
 
-	function addSnippet($name, $content);
+	function addSnippet(string $name, string $content): void;
 
-	function renderChildren();
+	function renderChildren(): void;
 }

--- a/tests/Latte/CoreMacros.templateType.php74.phpt
+++ b/tests/Latte/CoreMacros.templateType.php74.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Test: Latte\CoreMacros: {templateType ClassWithTypes}
+ */
+
+declare(strict_types=1);
+
+use Latte\Macros\CoreMacros;
+use Tester\Assert;
+use Tester\Environment;
+use Tester\FileMock;
+
+require __DIR__ . '/../bootstrap.php';
+
+if (PHP_VERSION_ID < 70400) {
+	Environment::skip('Typed properties cannot be tested with PHP < 7.4');
+}
+
+$compiler = new Latte\Compiler;
+CoreMacros::install($compiler);
+
+test(function () use ($compiler) {
+	require FileMock::create('
+	class TemplateTypeClass
+	{
+		public string $publicTyped;
+		private int $privateTyped;
+	}
+	', 'php');
+
+	Assert::same(
+		'<?php /** @var string $publicTyped */ ?>',
+		$compiler->expandMacro('templateType', TemplateTypeClass::class)->openingCode
+	);
+});

--- a/tests/Latte/CoreMacros.templateType.phpt
+++ b/tests/Latte/CoreMacros.templateType.phpt
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Test: Latte\CoreMacros: {templateType ClassWithTypes}
+ */
+
+declare(strict_types=1);
+
+use Latte\Macros\CoreMacros;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$compiler = new Latte\Compiler;
+CoreMacros::install($compiler);
+
+test(function () use ($compiler) {
+	class TemplateTypeClass
+	{
+		public $publicMixed;
+		/** @var string */
+		public $publicAnnotated;
+		private $privateMixed;
+	}
+
+	Assert::same(
+		'<?php /** @var mixed $publicMixed *//** @var string $publicAnnotated */ ?>',
+		$compiler->expandMacro('templateType', TemplateTypeClass::class)->openingCode
+	);
+});
+
+test(function () use ($compiler) {
+	Assert::exception(function () use ($compiler) {
+		$compiler->expandMacro('templateType', 'foo');
+	}, Latte\CompileException::class, 'Unknown type foo in {templateType}. Expected name of class or interface.');
+});

--- a/tests/Latte/CoreMacros.varType.phpt
+++ b/tests/Latte/CoreMacros.varType.phpt
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Test: Latte\CoreMacros: {varType type $var}
+ */
+
+declare(strict_types=1);
+
+use Latte\Macros\CoreMacros;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$compiler = new Latte\Compiler;
+CoreMacros::install($compiler);
+
+test(function () use ($compiler) {
+	Assert::same('<?php /** @var string $var */ ?>', $compiler->expandMacro('varType', 'string', '$var')->openingCode);
+	Assert::same('<?php /** @var ExampleClass|null $var */ ?>', $compiler->expandMacro('varType', 'ExampleClass|null', '$var')->openingCode);
+
+	Assert::exception(function () use ($compiler) {
+		$compiler->expandMacro('varType', 'string');
+	}, Latte\CompileException::class, 'Missing variable type or name in {varType}');
+
+	Assert::exception(function () use ($compiler) {
+		$compiler->expandMacro('varType', '');
+	}, Latte\CompileException::class, 'Missing variable type or name in {varType}');
+});

--- a/tests/Latte/PhpWriter.formatArgs().phpt
+++ b/tests/Latte/PhpWriter.formatArgs().phpt
@@ -137,6 +137,7 @@ test(function () { // optionalChainingPass
 	Assert::same('$a', formatArgs('$a'));
 	Assert::same('($a ?? null)', formatArgs('$a?'));
 	Assert::same('(($a ?? null))', formatArgs('($a?)'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : $_tmp[1])', formatArgs('$foo?[1]'));
 	Assert::same('$var->prop->elem[1]->call(2)->item', formatArgs('$var->prop->elem[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var ?? null) === null ? null : (($_tmp = $_tmp->prop ?? null) === null ? null : (($_tmp = $_tmp->elem[1] ?? null) === null ? null : (($_tmp = $_tmp->call(2) ?? null) === null ? null : ($_tmp->item ?? null)))))', formatArgs('$var?->prop?->elem[1]?->call(2)?->item?'));
 });

--- a/tests/Latte/PhpWriter.formatModifiers().phpt
+++ b/tests/Latte/PhpWriter.formatModifiers().phpt
@@ -70,6 +70,7 @@ test(function () { // depth
 test(function () { // optionalChainingPass
 	Assert::same('($this->filters->mod)(@, ($a ?? null))', formatModifiers('@', 'mod:$a?'));
 	Assert::same('($this->filters->mod)(@, (($a ?? null)))', formatModifiers('@', 'mod:($a?)'));
+	Assert::same('($this->filters->mod)(@, (($_tmp = $foo ?? null) === null ? null : $_tmp[1]))', formatModifiers('@', 'mod:$foo?[1]'));
 	Assert::same('($this->filters->mod)(@, (($_tmp = $var ?? null) === null ? null : (($_tmp = $_tmp->prop ?? null) === null ? null : (($_tmp = $_tmp->elem[1] ?? null) === null ? null : (($_tmp = $_tmp->call(2) ?? null) === null ? null : ($_tmp->item ?? null))))))', formatModifiers('@', 'mod:$var?->prop?->elem[1]?->call(2)?->item?'));
 });
 

--- a/tests/Latte/PhpWriter.optionalChainingPass().phpt
+++ b/tests/Latte/PhpWriter.optionalChainingPass().phpt
@@ -22,8 +22,15 @@ test(function () {
 	Assert::same('($a ?? null)', optionalChaining('$a?'));
 	Assert::same('(($a ?? null))', optionalChaining('($a?)'));
 	Assert::same('a?', optionalChaining('a?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : $_tmp[1])', optionalChaining('$foo?[1]'));
 	Assert::same('($foo[1] ?? null)', optionalChaining('$foo[1]?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[1] ?? null))', optionalChaining('$foo?[1]?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[1] ?? null)) + 10', optionalChaining('$foo?[1]? + 10'));
 	Assert::same('(($foo[1] ?? null))', optionalChaining('($foo[1]?)'));
+	Assert::same('((($_tmp = $foo ?? null) === null ? null : $_tmp[1]))', optionalChaining('($foo?[1])'));
+	Assert::same('[(($_tmp = $foo ?? null) === null ? null : ($_tmp[1] ?? null))]', optionalChaining('[$foo?[1]?]'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[ ($a ?? null) ] ?? null))', optionalChaining('$foo?[ $a? ]?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[ (($_tmp = $a ?? null) === null ? null : ($_tmp[2] ?? null)) ] ?? null))', optionalChaining('$foo?[ $a?[2]? ]?'));
 
 	Assert::same('(($_tmp = $foo ?? null) === null ? null : $_tmp->prop)', optionalChaining('$foo?->prop'));
 	Assert::same('($foo->prop ?? null)', optionalChaining('$foo->prop?'));
@@ -50,17 +57,20 @@ test(function () {
 	Assert::same('$var->prop->elem[1]->call(2)->item', optionalChaining('$var->prop->elem[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var ?? null) === null ? null : $_tmp->prop->elem[1]->call(2)->item)', optionalChaining('$var?->prop->elem[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var->prop ?? null) === null ? null : $_tmp->elem[1]->call(2)->item)', optionalChaining('$var->prop?->elem[1]->call(2)->item'));
+	Assert::same('(($_tmp = $var->prop->elem ?? null) === null ? null : $_tmp[1]->call(2)->item)', optionalChaining('$var->prop->elem?[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var->prop->elem[1] ?? null) === null ? null : $_tmp->call(2)->item)', optionalChaining('$var->prop->elem[1]?->call(2)->item'));
 	Assert::same('(($_tmp = $var->prop->elem[1]->call(2) ?? null) === null ? null : $_tmp->item)', optionalChaining('$var->prop->elem[1]->call(2)?->item'));
 	Assert::same('($var->prop->elem[1]->call(2)->item ?? null)', optionalChaining('$var->prop->elem[1]->call(2)->item?'));
+	Assert::same(
+		'(($_tmp = $var ?? null) === null ? null : (($_tmp = $_tmp->prop ?? null) === null ? null : (($_tmp = $_tmp->elem ?? null) === null ? null : (($_tmp = $_tmp[1] ?? null) === null ? null : (($_tmp = $_tmp->call(2) ?? null) === null ? null : ($_tmp->item ?? null))))))',
+		optionalChaining('$var?->prop?->elem?[1]?->call(2)?->item?')
+	);
 });
 
 
 test(function () { // not allowed
 	Assert::same('$foo ?(hello)', optionalChaining('$foo?(hello)'));
 	Assert::same('$foo->foo ?(hello)', optionalChaining('$foo->foo?(hello)'));
-
-	Assert::same('$foo ?[1]', optionalChaining('$foo?[1]')); // not allowed due to collision with short ternary
 });
 
 

--- a/tests/Latte/mocks/SnippetBridge.php
+++ b/tests/Latte/mocks/SnippetBridge.php
@@ -18,19 +18,19 @@ class SnippetBridgeMock implements Latte\Runtime\ISnippetBridge
 	}
 
 
-	public function setSnippetMode($snippetMode)
+	public function setSnippetMode(bool $snippetMode)
 	{
 		$this->snippetMode = $snippetMode;
 	}
 
 
-	public function needsRedraw($name): bool
+	public function needsRedraw(string $name): bool
 	{
 		return $this->invalid === true || isset($this->invalid[$name]);
 	}
 
 
-	public function markRedrawn($name): void
+	public function markRedrawn(string $name): void
 	{
 		if ($this->invalid !== true) {
 			unset($this->invalid[$name]);
@@ -38,13 +38,13 @@ class SnippetBridgeMock implements Latte\Runtime\ISnippetBridge
 	}
 
 
-	public function getHtmlId($name): string
+	public function getHtmlId(string $name): string
 	{
 		return $name;
 	}
 
 
-	public function addSnippet($name, $content): void
+	public function addSnippet(string $name, string $content): void
 	{
 		$this->payload[$name] = $content;
 	}


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: let's talk about implementation first

Added support for `{varType string $foo}` and `{templateType TemplateClass}`

TODOs
- `@property` and `@property-read` support for `{templateType}`

Refs
- [typed templates (czech only)](https://phpfashion.com/phpstorm-a-napovidani-nad-this-template)
- [phpstorm latte plugin implementation](https://github.com/mesour/intellij-latte/tree/mn-php-content-and-classes)

cc @mesour