### PR TITLE
Filters: Update `json_encode()` to PHP 7+ style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ after_failure:
 jobs:
     include:
         -   name: Nette Code Checker
+        	php: 7.4
             install:
                 - travis_retry composer create-project nette/code-checker temp/code-checker ^3 --no-progress
             script:
@@ -29,6 +30,7 @@ jobs:
 
 
         -   name: Nette Coding Standard
+        	php: 7.4
             install:
                 - travis_retry composer create-project nette/coding-standard temp/coding-standard ^2 --no-progress
             script:
@@ -41,7 +43,7 @@ jobs:
 
 
         -   stage: Code Coverage
-            php: 7.2
+        	php: 7.4
             script:
                 - vendor/bin/tester -p phpdbg tests -s -c tests/php-unix.ini --coverage ./coverage.xml --coverage-src ./src
             after_script:

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,14 @@
 		"nette/tester": "~2.0",
 		"tracy/tracy": "^2.3",
 		"nette/utils": "^3.0",
-		"phpstan/phpstan": "^0.12"
+		"phpstan/phpstan": "^0.12",
+		"nette/php-generator": "^3.3.4"
 	},
 	"suggest": {
 		"ext-mbstring": "to use filters like lower, upper, capitalize, ...",
 		"ext-fileinfo": "to use filter |datastream",
-		"nette/utils": "to use filter |webalize"
+		"nette/utils": "to use filter |webalize",
+		"nette/php-generator": "to use tag {templatePrint}"
 	},
 	"conflict": {
 		"nette/application": "<2.4.1"

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.7-dev"
+			"dev-master": "3.0-dev"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"nette/php-generator": "to use tag {templatePrint}"
 	},
 	"conflict": {
-		"nette/application": "<2.4.1"
+		"nette/application": "<3.0"
 	},
 	"autoload": {
 		"classmap": ["src/"]

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.6-dev"
+			"dev-master": "2.7-dev"
 		}
 	}
 }

--- a/src/Latte/Compiler/PhpWriter.php
+++ b/src/Latte/Compiler/PhpWriter.php
@@ -251,32 +251,23 @@ class PhpWriter
 	public function shortTernaryPass(MacroTokens $tokens): MacroTokens
 	{
 		$res = new MacroTokens;
-		$inTernary = $tmp = [];
-		$errors = 0;
+		$inTernary = [];
 		while ($tokens->nextToken()) {
-			if ($tokens->isCurrent('?') && $tokens->isNext() && !$tokens->isNext(',', ')', ']', '|')) {
+			if ($tokens->isCurrent('?') && $tokens->isNext() && !$tokens->isNext(',', ')', ']', '|', '[')) {
 				$inTernary[] = $tokens->depth;
-				$tmp[] = $tokens->isNext('[');
 
 			} elseif ($tokens->isCurrent(':')) {
 				array_pop($inTernary);
-				array_pop($tmp);
 
 			} elseif ($tokens->isCurrent(',', ')', ']', '|') && end($inTernary) === $tokens->depth + $tokens->isCurrent(')', ']')) {
 				$res->append(' : null');
 				array_pop($inTernary);
-				$errors += array_pop($tmp);
 			}
 			$res->append($tokens->currentToken());
 		}
 
 		if ($inTernary) {
-			$errors += array_pop($tmp);
 			$res->append(' : null');
-		}
-		if ($errors) {
-			$tokens->reset();
-			trigger_error('Short ternary operator requires parentheses around array in ' . $tokens->joinAll(), E_USER_DEPRECATED);
 		}
 		return $res;
 	}

--- a/src/Latte/Compiler/PhpWriter.php
+++ b/src/Latte/Compiler/PhpWriter.php
@@ -293,14 +293,14 @@ class PhpWriter
 
 			do {
 				if ($tokens->nextToken('?')) {
-					if ($tokens->isNext() && (!$tokens->isNext($tokens::T_CHAR) || $tokens->isNext('(', '[', '{', ':', '!', '@', '\\'))) {  // is it ternary operator?
+					if ($tokens->isNext() && (!$tokens->isNext($tokens::T_CHAR) || $tokens->isNext('(', '{', ':', '!', '@', '\\'))) {  // is it ternary operator?
 						$expr->append($addBraces . ' ?');
 						break;
 					}
 
 					$rescue = [$res->tokens, $expr->tokens, $tokens->position, $addBraces];
 
-					if (!$tokens->isNext('->')) {
+					if (!$tokens->isNext('->', '[')) {
 						$expr->prepend('(');
 						$expr->append(' ?? null)' . $addBraces);
 						break;

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -76,7 +76,7 @@ class Engine
 	 */
 	public function render(string $name, array $params = [], string $block = null): void
 	{
-		$this->createTemplate($name, $params + ['_renderblock' => $block])
+		$this->createTemplate($name, $params + ($block ? ['_renderblock' => $block] : []))
 			->render();
 	}
 
@@ -86,7 +86,7 @@ class Engine
 	 */
 	public function renderToString(string $name, array $params = [], string $block = null): string
 	{
-		$template = $this->createTemplate($name, $params + ['_renderblock' => $block]);
+		$template = $this->createTemplate($name, $params + ($block ? ['_renderblock' => $block] : []));
 		return $template->capture([$template, 'render']);
 	}
 

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -66,7 +66,8 @@ class Engine
 
 	public function __construct()
 	{
-		$this->filters = new Runtime\FilterExecutor;
+		$defaults = new Runtime\Defaults;
+		$this->filters = new Runtime\FilterExecutor($defaults->getFilters());
 		$this->functions = new \stdClass;
 	}
 

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -18,6 +18,7 @@ class Engine
 	use Strict;
 
 	public const VERSION = '2.7.0-dev';
+	public const VERSION_ID = 20700;
 
 	/** Content types */
 	public const

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -17,7 +17,7 @@ class Engine
 {
 	use Strict;
 
-	public const VERSION = '2.6.1';
+	public const VERSION = '2.7.0-dev';
 
 	/** Content types */
 	public const

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -73,20 +73,22 @@ class Engine
 
 	/**
 	 * Renders template to output.
+	 * @param  object|array  $params
 	 */
-	public function render(string $name, array $params = [], string $block = null): void
+	public function render(string $name, $params = [], string $block = null): void
 	{
-		$this->createTemplate($name, $params + ($block ? ['_renderblock' => $block] : []))
+		$this->createTemplate($name, (array) $params + ($block ? ['_renderblock' => $block] : []))
 			->render();
 	}
 
 
 	/**
 	 * Renders template to string.
+	 * @param  object|array  $params
 	 */
-	public function renderToString(string $name, array $params = [], string $block = null): string
+	public function renderToString(string $name, $params = [], string $block = null): string
 	{
-		$template = $this->createTemplate($name, $params + ($block ? ['_renderblock' => $block] : []));
+		$template = $this->createTemplate($name, (array) $params + ($block ? ['_renderblock' => $block] : []));
 		return $template->capture([$template, 'render']);
 	}
 

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -39,7 +39,7 @@ class Engine
 	/** @var Compiler|null */
 	private $compiler;
 
-	/** @var ILoader|null */
+	/** @var Loader|null */
 	private $loader;
 
 	/** @var Runtime\FilterExecutor */
@@ -372,14 +372,14 @@ class Engine
 
 
 	/** @return static */
-	public function setLoader(ILoader $loader)
+	public function setLoader(Loader $loader)
 	{
 		$this->loader = $loader;
 		return $this;
 	}
 
 
-	public function getLoader(): ILoader
+	public function getLoader(): Loader
 	{
 		if (!$this->loader) {
 			$this->loader = new Loaders\FileLoader;

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -17,8 +17,8 @@ class Engine
 {
 	use Strict;
 
-	public const VERSION = '2.7.0-dev';
-	public const VERSION_ID = 20700;
+	public const VERSION = '3.3.0-dev';
+	public const VERSION_ID = 30000;
 
 	/** Content types */
 	public const

--- a/src/Latte/Helpers.php
+++ b/src/Latte/Helpers.php
@@ -67,4 +67,21 @@ class Helpers
 	{
 		return strncmp($haystack, $needle, strlen($needle)) === 0;
 	}
+
+
+	/**
+	 * @param  callable  $callable  is escalated to \InvalidArgumentException
+	 */
+	public static function toReflection($callable): \ReflectionFunctionAbstract
+	{
+		if (is_string($callable) && strpos($callable, '::')) {
+			return new \ReflectionMethod($callable);
+		} elseif (is_array($callable)) {
+			return new \ReflectionMethod($callable[0], $callable[1]);
+		} elseif (is_object($callable) && !$callable instanceof \Closure) {
+			return new \ReflectionMethod($callable, '__invoke');
+		} else {
+			return new \ReflectionFunction($callable);
+		}
+	}
 }

--- a/src/Latte/Loader.php
+++ b/src/Latte/Loader.php
@@ -13,7 +13,7 @@ namespace Latte;
 /**
  * Template loader.
  */
-interface ILoader
+interface Loader
 {
 	/**
 	 * Returns template source code.
@@ -35,3 +35,6 @@ interface ILoader
 	 */
 	function getUniqueId($name);
 }
+
+
+class_exists(ILoader::class);

--- a/src/Latte/Loaders/FileLoader.php
+++ b/src/Latte/Loaders/FileLoader.php
@@ -15,7 +15,7 @@ use Latte;
 /**
  * Template loader.
  */
-class FileLoader implements Latte\ILoader
+class FileLoader implements Latte\Loader
 {
 	use Latte\Strict;
 

--- a/src/Latte/Loaders/StringLoader.php
+++ b/src/Latte/Loaders/StringLoader.php
@@ -15,7 +15,7 @@ use Latte;
 /**
  * Template loader.
  */
-class StringLoader implements Latte\ILoader
+class StringLoader implements Latte\Loader
 {
 	use Latte\Strict;
 

--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -70,6 +70,7 @@ class CoreMacros extends MacroSet
 
 		$me->addMacro('varType', [$me, 'macroVarType'], null, null, self::ALLOWED_IN_HEAD);
 		$me->addMacro('templateType', [$me, 'macroTemplateType'], null, null, self::ALLOWED_IN_HEAD);
+		$me->addMacro('templatePrint', [$me, 'macroTemplatePrint'], null, null, self::ALLOWED_IN_HEAD);
 	}
 
 
@@ -544,5 +545,15 @@ class CoreMacros extends MacroSet
 		} elseif (!($type = $node->tokenizer->fetchWord())) {
 			throw new CompileException('Missing class name in {templateType} macro.');
 		}
+	}
+
+
+	/**
+	 * {templatePrint [ClassName]}
+	 */
+	public function macroTemplatePrint(MacroNode $node, PhpWriter $writer)
+	{
+		$class = $node->tokenizer->fetchWord() ?: null;
+		return $writer->write('@ob_end_clean(); header("Content-Type: text/plain"); echo (new Latte\Runtime\TemplatePrinter)->print($this, %var); exit;', $class);
 	}
 }

--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -71,6 +71,8 @@ class CoreMacros extends MacroSet
 		$me->addMacro('varType', [$me, 'macroVarType'], null, null, self::ALLOWED_IN_HEAD);
 		$me->addMacro('templateType', [$me, 'macroTemplateType'], null, null, self::ALLOWED_IN_HEAD);
 		$me->addMacro('templatePrint', [$me, 'macroTemplatePrint'], null, null, self::ALLOWED_IN_HEAD);
+
+		$me->addMacro('nonce', null, null, 'echo $this->global->coreNonce ? " nonce=\"{$this->global->coreNonce}\"" : "";');
 	}
 
 

--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -415,6 +415,10 @@ class CoreMacros extends MacroSet
 		$tokens = $writer->preprocess();
 		$res = new Latte\MacroTokens;
 		while ($tokens->nextToken()) {
+			if ($var && $tokens->isCurrent($tokens::T_SYMBOL)) {
+				trigger_error("Inside macro {{$node->name} {$node->args}} should be '{$tokens->currentValue()}' replaced with '\${$tokens->currentValue()}'", E_USER_DEPRECATED);
+			}
+
 			if ($var && $tokens->isCurrent($tokens::T_SYMBOL, $tokens::T_VARIABLE)) {
 				if ($node->name === 'default') {
 					$res->append("'" . ltrim($tokens->currentValue(), '$') . "'");
@@ -424,6 +428,9 @@ class CoreMacros extends MacroSet
 				$var = null;
 
 			} elseif ($tokens->isCurrent('=', '=>') && $tokens->depth === 0) {
+				if ($tokens->isCurrent('=>')) {
+					trigger_error("Inside macro {{$node->name} {$node->args}} should be => replaced with =", E_USER_DEPRECATED);
+				}
 				$res->append($node->name === 'default' ? '=>' : '=');
 				$var = false;
 

--- a/src/Latte/Macros/CoreMacros.php
+++ b/src/Latte/Macros/CoreMacros.php
@@ -67,6 +67,9 @@ class CoreMacros extends MacroSet
 
 		$me->addMacro('class', null, null, [$me, 'macroClass']);
 		$me->addMacro('attr', null, null, [$me, 'macroAttr']);
+
+		$me->addMacro('varType', [$me, 'macroVarType'], null, null, self::ALLOWED_IN_HEAD);
+		$me->addMacro('templateType', [$me, 'macroTemplateType'], null, null, self::ALLOWED_IN_HEAD);
 	}
 
 
@@ -508,6 +511,38 @@ class CoreMacros extends MacroSet
 
 		if (strpos($node->args, '/') && !$node->htmlNode) {
 			return $writer->write('if (empty($this->global->coreCaptured) && in_array($this->getReferenceType(), ["extends", null], true)) header(%var);', "Content-Type: $node->args");
+		}
+	}
+
+
+	/**
+	 * {varType type $var}
+	 */
+	public function macroVarType(MacroNode $node, PhpWriter $writer)
+	{
+		if ($node->modifiers) {
+			throw new CompileException('Modifiers are not allowed in ' . $node->getNotation());
+		}
+
+		$type = $node->tokenizer->fetchWord();
+		$variable = $node->tokenizer->fetchWord();
+		if (!$type || !$variable || !Helpers::startsWith($variable, '$')) {
+			throw new CompileException('Unexpected content, expecting {varType type $var}.');
+		}
+	}
+
+
+	/**
+	 * {templateType ClassName}
+	 */
+	public function macroTemplateType(MacroNode $node, PhpWriter $writer)
+	{
+		if (!$this->getCompiler()->isInHead()) {
+			throw new CompileException($node->getNotation() . ' is allowed only in template header.');
+		} elseif ($node->modifiers) {
+			throw new CompileException('Modifiers are not allowed in ' . $node->getNotation());
+		} elseif (!($type = $node->tokenizer->fetchWord())) {
+			throw new CompileException('Missing class name in {templateType} macro.');
 		}
 	}
 }

--- a/src/Latte/Macros/MacroSet.php
+++ b/src/Latte/Macros/MacroSet.php
@@ -107,9 +107,12 @@ class MacroSet implements Latte\IMacro
 			}
 			$node->context[1] = Latte\Compiler::CONTEXT_HTML_TEXT;
 
+		} elseif ($node->empty && $node->prefix) {
+			return false;
+
 		} elseif ($begin) {
 			$res = $this->compile($node, $begin);
-			if ($res === false || ($node->empty && $node->prefix)) {
+			if ($res === false) {
 				return false;
 			} elseif (!$node->openingCode && is_string($res) && $res !== '') {
 				$node->openingCode = "<?php $res ?>";

--- a/src/Latte/Runtime/Defaults.php
+++ b/src/Latte/Runtime/Defaults.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the Latte (https://latte.nette.org)
+ * Copyright (c) 2008 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Latte\Runtime;
+
+
+/**
+ * @internal
+ */
+class Defaults
+{
+	/** @var array<string,callable> */
+	private $list = [
+		'breakLines' => [Filters::class, 'breaklines'],
+		'bytes' => [Filters::class, 'bytes'],
+		'capitalize' => [Filters::class, 'capitalize'],
+		'dataStream' => [Filters::class, 'dataStream'],
+		'date' => [Filters::class, 'date'],
+		'escapeCss' => [Filters::class, 'escapeCss'],
+		'escapeHtml' => [Filters::class, 'escapeHtml'],
+		'escapeHtmlComment' => [Filters::class, 'escapeHtmlComment'],
+		'escapeICal' => [Filters::class, 'escapeICal'],
+		'escapeJs' => [Filters::class, 'escapeJs'],
+		'escapeUrl' => 'rawurlencode',
+		'escapeXml' => [Filters::class, 'escapeXml'],
+		'firstUpper' => [Filters::class, 'firstUpper'],
+		'checkUrl' => [Filters::class, 'safeUrl'],
+		'implode' => [Filters::class, 'implode'],
+		'indent' => [Filters::class, 'indent'],
+		'length' => [Filters::class, 'length'],
+		'lower' => [Filters::class, 'lower'],
+		'number' => 'number_format',
+		'padLeft' => [Filters::class, 'padLeft'],
+		'padRight' => [Filters::class, 'padRight'],
+		'repeat' => [Filters::class, 'repeat'],
+		'replace' => [Filters::class, 'replace'],
+		'replaceRe' => [Filters::class, 'replaceRe'],
+		'reverse' => [Filters::class, 'reverse'],
+		'strip' => [Filters::class, 'strip'],
+		'stripHtml' => [Filters::class, 'stripHtml'],
+		'stripTags' => [Filters::class, 'stripTags'],
+		'substr' => [Filters::class, 'substring'],
+		'trim' => [Filters::class, 'trim'],
+		'truncate' => [Filters::class, 'truncate'],
+		'upper' => [Filters::class, 'upper'],
+		'webalize' => [\Nette\Utils\Strings::class, 'webalize'],
+	];
+
+
+	/** @return array<string,callable> */
+	public function getFilters(): array
+	{
+		return $this->list;
+	}
+}

--- a/src/Latte/Runtime/Defaults.php
+++ b/src/Latte/Runtime/Defaults.php
@@ -17,6 +17,7 @@ class Defaults
 {
 	/** @var array<string,callable> */
 	private $list = [
+		'batch' => [Filters::class, 'batch'],
 		'breakLines' => [Filters::class, 'breaklines'],
 		'bytes' => [Filters::class, 'bytes'],
 		'capitalize' => [Filters::class, 'capitalize'],

--- a/src/Latte/Runtime/FilterExecutor.php
+++ b/src/Latte/Runtime/FilterExecutor.php
@@ -23,41 +23,15 @@ class FilterExecutor
 	private $_dynamic = [];
 
 	/** @var array [name => [callback, FilterInfo aware] */
-	private $_static = [
-		'breaklines' => [[Filters::class, 'breaklines'], false],
-		'bytes' => [[Filters::class, 'bytes'], false],
-		'capitalize' => [[Filters::class, 'capitalize'], false],
-		'datastream' => [[Filters::class, 'dataStream'], false],
-		'date' => [[Filters::class, 'date'], false],
-		'escapecss' => [[Filters::class, 'escapeCss'], false],
-		'escapehtml' => [[Filters::class, 'escapeHtml'], false],
-		'escapehtmlcomment' => [[Filters::class, 'escapeHtmlComment'], false],
-		'escapeical' => [[Filters::class, 'escapeICal'], false],
-		'escapejs' => [[Filters::class, 'escapeJs'], false],
-		'escapeurl' => ['rawurlencode', false],
-		'escapexml' => [[Filters::class, 'escapeXml'], false],
-		'firstupper' => [[Filters::class, 'firstUpper'], false],
-		'checkurl' => [[Filters::class, 'safeUrl'], false],
-		'implode' => [[Filters::class, 'implode'], false],
-		'indent' => [[Filters::class, 'indent'], true],
-		'length' => [[Filters::class, 'length'], false],
-		'lower' => [[Filters::class, 'lower'], false],
-		'number' => ['number_format', false],
-		'padleft' => [[Filters::class, 'padLeft'], false],
-		'padright' => [[Filters::class, 'padRight'], false],
-		'repeat' => [[Filters::class, 'repeat'], true],
-		'replace' => [[Filters::class, 'replace'], true],
-		'replacere' => [[Filters::class, 'replaceRe'], false],
-		'reverse' => [[Filters::class, 'reverse'], false],
-		'strip' => [[Filters::class, 'strip'], true],
-		'striphtml' => [[Filters::class, 'stripHtml'], true],
-		'striptags' => [[Filters::class, 'stripTags'], true],
-		'substr' => [[Filters::class, 'substring'], false],
-		'trim' => [[Filters::class, 'trim'], true],
-		'truncate' => [[Filters::class, 'truncate'], false],
-		'upper' => [[Filters::class, 'upper'], false],
-		'webalize' => [[\Nette\Utils\Strings::class, 'webalize'], false],
-	];
+	private $_static = [];
+
+
+	public function __construct(array $list = [])
+	{
+		foreach ($list as $name => $callback) {
+			$this->_static[strtolower($name)] = [$callback, null];
+		}
+	}
 
 
 	/**

--- a/src/Latte/Runtime/FilterExecutor.php
+++ b/src/Latte/Runtime/FilterExecutor.php
@@ -168,18 +168,10 @@ class FilterExecutor
 	private function prepareFilter(string $name): array
 	{
 		if (!isset($this->_static[$name][1])) {
-			$callback = $this->_static[$name][0];
-			if (is_string($callback) && strpos($callback, '::')) {
-				$callback = explode('::', $callback);
-			} elseif (is_object($callback)) {
-				$callback = [$callback, '__invoke'];
-			}
-			$ref = is_array($callback)
-				? new \ReflectionMethod($callback[0], $callback[1])
-				: new \ReflectionFunction($callback);
-			$this->_static[$name][1] = ($tmp = $ref->getParameters())
-				&& $tmp[0]->getType() instanceof \ReflectionNamedType
-				&& $tmp[0]->getType()->getName() === FilterInfo::class;
+			$params = Helpers::toReflection($this->_static[$name][0])->getParameters();
+			$this->_static[$name][1] = $params
+				&& $params[0]->getType() instanceof \ReflectionNamedType
+				&& $params[0]->getType()->getName() === FilterInfo::class;
 		}
 		return $this->_static[$name];
 	}

--- a/src/Latte/Runtime/FilterExecutor.php
+++ b/src/Latte/Runtime/FilterExecutor.php
@@ -75,7 +75,7 @@ class FilterExecutor
 			if ($aware) { // FilterInfo aware filter
 				return $this->$lname = function (...$args) use ($callback) {
 					array_unshift($args, $info = new FilterInfo);
-					if ($args[1] instanceof IHtmlString) {
+					if ($args[1] instanceof HtmlString) {
 						$args[1] = $args[1]->__toString();
 						$info->contentType = Engine::CONTENT_HTML;
 					}
@@ -129,7 +129,7 @@ class FilterExecutor
 					. ($info->contentType === Engine::CONTENT_HTML ? ', try to prepend |stripHtml.' : '.'), E_USER_WARNING);
 			}
 			$res = ($this->$name)(...$args);
-			if ($res instanceof IHtmlString) {
+			if ($res instanceof HtmlString) {
 				trigger_error("Filter |$name should be changed to content-aware filter.");
 				$info->contentType = Engine::CONTENT_HTML;
 				$res = $res->__toString();

--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -162,12 +162,14 @@ class Filters
 			$s = $s->__toString(true);
 		}
 
-		$json = json_encode($s, JSON_UNESCAPED_UNICODE);
-		if ($error = json_last_error()) {
-			throw new \RuntimeException(json_last_error_msg(), $error);
+		try {
+			$json = json_encode($s, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+			return str_replace([']]>', '<!'], [']]\x3E', '\x3C!'], $json);
+		} catch (\JsonException $exception) {
+			throw new \RuntimeException($exception->getMessage(), $exception->getCode(), $exception);
 		}
 
-		return str_replace([']]>', '<!'], [']]\x3E', '\x3C!'], $json);
 	}
 
 

--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -651,6 +651,32 @@ class Filters
 
 
 	/**
+	 * Chunks items by returning an array of arrays with the given number of items.
+	 * @param  array|\Traversable  $list
+	 */
+	public static function batch($list, int $size, $rest = null): \Generator
+	{
+		$batch = [];
+		foreach ($list as $key => $value) {
+			$batch[$key] = $value;
+			if (count($batch) >= $size) {
+				yield $batch;
+				$batch = [];
+			}
+		}
+
+		if ($batch) {
+			if ($rest !== null) {
+				while (count($batch) < $size) {
+					$batch[] = $rest;
+				}
+			}
+			yield $batch;
+		}
+	}
+
+
+	/**
 	 * Returns element's attributes.
 	 */
 	public static function htmlAttributes($attrs): string

--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -39,12 +39,12 @@ class Filters
 
 	/**
 	 * Escapes string for use inside HTML text.
-	 * @param  mixed  $s  plain text or IHtmlString
+	 * @param  mixed  $s  plain text or HtmlString
 	 * @return string HTML
 	 */
 	public static function escapeHtmlText($s): string
 	{
-		return $s instanceof IHtmlString || $s instanceof \Nette\Utils\IHtmlString
+		return $s instanceof HtmlString || $s instanceof \Nette\Utils\HtmlString
 			? $s->__toString(true)
 			: htmlspecialchars((string) $s, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 	}
@@ -57,7 +57,7 @@ class Filters
 	 */
 	public static function escapeHtmlAttr($s, bool $double = true): string
 	{
-		$double = $double && $s instanceof IHtmlString ? false : $double;
+		$double = $double && $s instanceof HtmlString ? false : $double;
 		$s = (string) $s;
 		if (strpos($s, '`') !== false && strpbrk($s, ' <>"\'') === false) {
 			$s .= ' '; // protection against innerHTML mXSS vulnerability nette/nette#1496
@@ -158,7 +158,7 @@ class Filters
 	 */
 	public static function escapeJs($s): string
 	{
-		if ($s instanceof IHtmlString || $s instanceof \Nette\Utils\IHtmlString) {
+		if ($s instanceof HtmlString || $s instanceof \Nette\Utils\HtmlString) {
 			$s = $s->__toString(true);
 		}
 

--- a/src/Latte/Runtime/Html.php
+++ b/src/Latte/Runtime/Html.php
@@ -15,7 +15,7 @@ use Latte;
 /**
  * HTML literal.
  */
-class Html implements IHtmlString
+class Html implements HtmlString
 {
 	use Latte\Strict;
 

--- a/src/Latte/Runtime/HtmlString.php
+++ b/src/Latte/Runtime/HtmlString.php
@@ -10,9 +10,12 @@ declare(strict_types=1);
 namespace Latte\Runtime;
 
 
-interface IHtmlString
+interface HtmlString
 {
 
 	/** @return string in HTML format */
 	function __toString(): string;
 }
+
+
+class_exists(IHtmlString::class);

--- a/src/Latte/Runtime/SnippetBridge.php
+++ b/src/Latte/Runtime/SnippetBridge.php
@@ -14,7 +14,7 @@ namespace Latte\Runtime;
  * Snippet bridge
  * @internal
  */
-interface ISnippetBridge
+interface SnippetBridge
 {
 	function isSnippetMode();
 
@@ -30,3 +30,6 @@ interface ISnippetBridge
 
 	function renderChildren();
 }
+
+
+class_exists(ISnippetBridge::class);

--- a/src/Latte/Runtime/SnippetBridge.php
+++ b/src/Latte/Runtime/SnippetBridge.php
@@ -16,19 +16,19 @@ namespace Latte\Runtime;
  */
 interface SnippetBridge
 {
-	function isSnippetMode();
+	function isSnippetMode(): bool;
 
-	function setSnippetMode($snippetMode);
+	function setSnippetMode(bool $snippetMode);
 
-	function needsRedraw($name);
+	function needsRedraw(string $name): bool;
 
-	function markRedrawn($name);
+	function markRedrawn(string $name): void;
 
-	function getHtmlId($name);
+	function getHtmlId(string $name): string;
 
-	function addSnippet($name, $content);
+	function addSnippet(string $name, string $content): void;
 
-	function renderChildren();
+	function renderChildren(): void;
 }
 
 

--- a/src/Latte/Runtime/SnippetDriver.php
+++ b/src/Latte/Runtime/SnippetDriver.php
@@ -34,11 +34,11 @@ class SnippetDriver
 	/** @var bool */
 	private $renderingSnippets = false;
 
-	/** @var ISnippetBridge */
+	/** @var SnippetBridge */
 	private $bridge;
 
 
-	public function __construct(ISnippetBridge $bridge)
+	public function __construct(SnippetBridge $bridge)
 	{
 		$this->bridge = $bridge;
 	}

--- a/src/Latte/Runtime/Template.php
+++ b/src/Latte/Runtime/Template.php
@@ -166,10 +166,6 @@ class Template
 			}
 		}
 
-		// old accumulators for back compatibility
-		$this->params['_l'] = new \stdClass;
-		$this->params['_g'] = $this->global;
-		$this->params['_b'] = (object) ['blocks' => &$this->blockQueue, 'types' => &$this->blockTypes];
 		if (isset($this->global->snippetDriver) && $this->global->snippetBridge->isSnippetMode()) {
 			if ($this->global->snippetDriver->renderSnippets($this->blockQueue, $this->params)) {
 				return;

--- a/src/Latte/Runtime/TemplatePrinter.php
+++ b/src/Latte/Runtime/TemplatePrinter.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Latte\Runtime;
+
+use Latte;
+use Nette;
+use Nette\PhpGenerator as Php;
+
+
+/**
+ * Generates blueprint of template class.
+ */
+class TemplatePrinter
+{
+	use Latte\Strict;
+
+	public function print(Template $template, string $name = null): Php\PhpNamespace
+	{
+		if (!class_exists(Php\ClassType::class)) {
+			throw new \LogicException('Nette PhpGenerator is required to print template, install package `nette/php-generator`.');
+		}
+
+		$name = $name ?: 'Template';
+		$namespace = new Php\PhpNamespace(Php\Helpers::extractNamespace($name));
+		$class = $namespace->addClass(Php\Helpers::extractShortName($name));
+
+		$this->addProperties($class, $template->getParameters(), true);
+		$this->addProperties($class, $template->getParameters(), false);
+		$this->addFunctions($class, (array) $template->global->_fn);
+
+		return $namespace;
+	}
+
+
+	public function addProperties(Php\ClassType $class, array $props, bool $magic): void
+	{
+		$printer = new Php\Printer;
+		foreach ($props as $name => $value) {
+			$type = Php\Type::getType($value);
+			$doctype = $printer->printType($type, false, $class->getNamespace()) ?: 'mixed';
+			if ($magic) {
+				$class->addComment("@property $doctype $$name");
+			} else {
+				$prop = $class->addProperty($name);
+				if (PHP_VERSION_ID >= 70400) {
+					$prop->setType($type);
+				} else {
+					$prop->setComment("@var $doctype");
+				}
+			}
+		}
+	}
+
+
+	public function addFunctions(Php\ClassType $class, array $funcs): void
+	{
+		$printer = new Php\Printer;
+		foreach ($funcs as $name => $func) {
+			$method = (new Php\Factory)->fromCallable($func);
+			$type = $printer->printType($method->getReturnType(), $method->isReturnNullable(), $class->getNamespace()) ?: 'mixed';
+			$class->addComment("@method $type $name" . $printer->printParameters($method, $class->getNamespace()));
+		}
+	}
+}

--- a/src/compatibility.php
+++ b/src/compatibility.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Latte {
+	if (false) {
+		/** @deprecated use Latte\Loader */
+		interface ILoader
+		{
+		}
+	} elseif (!interface_exists(ILoader::class)) {
+		class_alias(Loader::class, ILoader::class);
+	}
+}
+
+namespace Latte\Runtime {
+	if (false) {
+		/** @deprecated use Latte\Runtime\HtmlString */
+		interface IHtmlString
+		{
+		}
+	} elseif (!interface_exists(IHtmlString::class)) {
+		class_alias(HtmlString::class, IHtmlString::class);
+	}
+
+	if (false) {
+		/** @deprecated use Latte\Runtime\SnippetBridge */
+		interface ISnippetBridge
+		{
+		}
+	} elseif (!interface_exists(ISnippetBridge::class)) {
+		class_alias(SnippetBridge::class, ISnippetBridge::class);
+	}
+}

--- a/tests/Latte/CoreMacros.nonce.phpt
+++ b/tests/Latte/CoreMacros.nonce.phpt
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Test: n:nonce
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$latte = new Latte\Engine;
+$latte->setLoader(new Latte\Loaders\StringLoader);
+$latte->addProvider('coreNonce', null);
+
+Assert::match(
+	'<script></script>',
+	$latte->renderToString('<script n:nonce></script>')
+);
+
+
+$latte->addProvider('coreNonce', 'djsdgidk');
+
+Assert::match(
+	'<script nonce="djsdgidk"></script>',
+	$latte->renderToString('<script n:nonce></script>')
+);

--- a/tests/Latte/CoreMacros.templateType.phpt
+++ b/tests/Latte/CoreMacros.templateType.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: {templateType}
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$latte = new Latte\Engine;
+$latte->setLoader(new Latte\Loaders\StringLoader);
+
+Assert::exception(function () use ($latte) {
+	$latte->compile('{templateType}');
+}, Latte\CompileException::class, 'Missing class name in {templateType} macro.');
+
+Assert::exception(function () use ($latte) {
+	$latte->compile('{if true}{templateType stdClass}{/if}');
+}, Latte\CompileException::class, '{templateType} is allowed only in template header.');
+
+Assert::noError(function () use ($latte) {
+	$latte->compile('{templateType stdClass}');
+});

--- a/tests/Latte/CoreMacros.var.default.phpt
+++ b/tests/Latte/CoreMacros.var.default.phpt
@@ -27,6 +27,15 @@ test(function () use ($compiler) { // {var ... }
 	Assert::same('<?php $var1 = 123; $var2 = "nette framework"; ?>', $compiler->expandMacro('var', '$var1 = 123, $var2 = "nette framework"', '')->openingCode);
 	Assert::same('<?php $temp->var1 = 123; ?>', $compiler->expandMacro('var', '$temp->var1 = 123', '')->openingCode);
 
+	// types
+	Assert::same('<?php ; ; ?>', $compiler->expandMacro('var', 'int var, string var2', '')->openingCode); // invalid syntax
+	Assert::same('<?php $temp->var1 = 123; ?>', $compiler->expandMacro('var', 'int $temp->var1 = 123', '')->openingCode);
+	Assert::same('<?php  $temp->var1 = 123; ?>', $compiler->expandMacro('var', 'null|int|?string[] $temp->var1 = 123', '')->openingCode);
+	Assert::same('<?php  $var1 = 123;  $var2 = "nette framework"; ?>', $compiler->expandMacro('var', 'int|string[] $var1 = 123, ?class|null $var2 = "nette framework"', '')->openingCode);
+	Assert::same('<?php  $var1 = 123;  $var2 = 456; ?>', $compiler->expandMacro('var', 'A\B $var1 = 123, ?A\B $var2 = 456', '')->openingCode);
+	Assert::same('<?php  $var1 = 123;  $var2 = 456; ?>', $compiler->expandMacro('var', '\A\B $var1 = 123, ?\A\B $var2 = 456', '')->openingCode);
+
+	// errors
 	Assert::exception(function () use ($compiler) {
 		$compiler->expandMacro('var', '$var => "123', '');
 	}, Latte\CompileException::class, 'Unexpected %a% on line 1, column 9.');
@@ -34,6 +43,9 @@ test(function () use ($compiler) { // {var ... }
 	Assert::exception(function () use ($compiler) {
 		$compiler->expandMacro('var', '$var => 123', '|filter');
 	}, Latte\CompileException::class, 'Modifiers are not allowed in {var}');
+
+	// preprocess
+	Assert::same("<?php \$temp->var1 = true ? 'a' : null; ?>", $compiler->expandMacro('var', '$temp->var1 = true ? a', '')->openingCode);
 });
 
 
@@ -46,6 +58,12 @@ test(function () use ($compiler) { // {default ...}
 	Assert::same("<?php extract(['var1' => 123, 'var2' => \"nette framework\"], EXTR_SKIP) ?>", @$compiler->expandMacro('default', 'var1 = 123, $var2 => "nette framework"', '')->openingCode); // @ deprecated syntax
 	Assert::same("<?php extract(['var1' => 123, 'var2' => \"nette framework\"], EXTR_SKIP) ?>", $compiler->expandMacro('default', '$var1 = 123, $var2 = "nette framework"', '')->openingCode);
 
+	// types
+	Assert::same('<?php extract([, ], EXTR_SKIP) ?>', $compiler->expandMacro('default', 'int var, string var2', '')->openingCode); // invalid syntax
+	Assert::same("<?php extract([ 'var' => 123], EXTR_SKIP) ?>", $compiler->expandMacro('default', 'null|int|?string[] $var = 123', '')->openingCode);
+	Assert::same("<?php extract([ 'var1' => 123,  'var2' => \"nette framework\"], EXTR_SKIP) ?>", $compiler->expandMacro('default', 'int|string[] $var1 = 123, ?class|null $var2 = "nette framework"', '')->openingCode);
+
+	// errors
 	Assert::exception(function () use ($compiler) {
 		$compiler->expandMacro('default', '$temp->var1 = 123', '');
 	}, Latte\CompileException::class, "Unexpected '->' in {default \$temp->var1 = 123}");
@@ -53,4 +71,7 @@ test(function () use ($compiler) { // {default ...}
 	Assert::exception(function () use ($compiler) {
 		$compiler->expandMacro('default', '$var => 123', '|filter');
 	}, Latte\CompileException::class, 'Modifiers are not allowed in {default}');
+
+	// preprocess
+	Assert::same("<?php extract(['var1' => true ? 'a' : null], EXTR_SKIP) ?>", $compiler->expandMacro('default', '$var1 = true ? a', '')->openingCode);
 });

--- a/tests/Latte/CoreMacros.var.default.phpt
+++ b/tests/Latte/CoreMacros.var.default.phpt
@@ -17,12 +17,14 @@ $compiler = new Latte\Compiler;
 CoreMacros::install($compiler);
 
 test(function () use ($compiler) { // {var ... }
-	Assert::same('<?php $var=null; $var2=null; ?>', $compiler->expandMacro('var', 'var, var2', '')->openingCode);
-	Assert::same('<?php $var = \'hello\'; ?>', $compiler->expandMacro('var', 'var => hello', '')->openingCode);
-	Assert::same('<?php $var = \'hello\'; $var2 = \'world\'; ?>', $compiler->expandMacro('var', 'var => hello, var2 = world', '')->openingCode);
-	Assert::same('<?php $var = 123; ?>', $compiler->expandMacro('var', '$var => 123', '')->openingCode);
+	Assert::same('<?php $var=null; $var2=null; ?>', @$compiler->expandMacro('var', 'var, var2', '')->openingCode); // @ deprecated syntax
+	Assert::same('<?php $var=null; $var2=null; ?>', $compiler->expandMacro('var', '$var, $var2', '')->openingCode);
+	Assert::same('<?php $var = \'hello\'; ?>', @$compiler->expandMacro('var', 'var => hello', '')->openingCode); // @ deprecated syntax
+	Assert::same('<?php $var = \'hello\'; $var2 = \'world\'; ?>', @$compiler->expandMacro('var', 'var => hello, var2 = world', '')->openingCode); // @ deprecated syntax
+	Assert::same('<?php $var = 123; ?>', @$compiler->expandMacro('var', '$var => 123', '')->openingCode); // @ deprecated syntax
 	Assert::same('<?php $var = 123; ?>', $compiler->expandMacro('var', '$var = 123', '')->openingCode);
-	Assert::same('<?php $var1 = 123; $var2 = "nette framework"; ?>', $compiler->expandMacro('var', 'var1 = 123, $var2 => "nette framework"', '')->openingCode);
+	Assert::same('<?php $var1 = 123; $var2 = "nette framework"; ?>', @$compiler->expandMacro('var', 'var1 = 123, $var2 => "nette framework"', '')->openingCode); // @ deprecated syntax
+	Assert::same('<?php $var1 = 123; $var2 = "nette framework"; ?>', $compiler->expandMacro('var', '$var1 = 123, $var2 = "nette framework"', '')->openingCode);
 	Assert::same('<?php $temp->var1 = 123; ?>', $compiler->expandMacro('var', '$temp->var1 = 123', '')->openingCode);
 
 	Assert::exception(function () use ($compiler) {
@@ -36,11 +38,13 @@ test(function () use ($compiler) { // {var ... }
 
 
 test(function () use ($compiler) { // {default ...}
-	Assert::same("<?php extract(['var'=>null, 'var2'=>null], EXTR_SKIP) ?>", $compiler->expandMacro('default', 'var, var2', '')->openingCode);
-	Assert::same("<?php extract(['var' => 'hello'], EXTR_SKIP) ?>", $compiler->expandMacro('default', 'var => hello', '')->openingCode);
-	Assert::same("<?php extract(['var' => 123], EXTR_SKIP) ?>", $compiler->expandMacro('default', '$var => 123', '')->openingCode);
+	Assert::same("<?php extract(['var'=>null, 'var2'=>null], EXTR_SKIP) ?>", @$compiler->expandMacro('default', 'var, var2', '')->openingCode); // @ deprecated syntax
+	Assert::same("<?php extract(['var'=>null, 'var2'=>null], EXTR_SKIP) ?>", $compiler->expandMacro('default', '$var, $var2', '')->openingCode);
+	Assert::same("<?php extract(['var' => 'hello'], EXTR_SKIP) ?>", @$compiler->expandMacro('default', 'var => hello', '')->openingCode); // @ deprecated syntax
+	Assert::same("<?php extract(['var' => 123], EXTR_SKIP) ?>", @$compiler->expandMacro('default', '$var => 123', '')->openingCode); // @ deprecated syntax
 	Assert::same("<?php extract(['var' => 123], EXTR_SKIP) ?>", $compiler->expandMacro('default', '$var = 123', '')->openingCode);
-	Assert::same("<?php extract(['var1' => 123, 'var2' => \"nette framework\"], EXTR_SKIP) ?>", $compiler->expandMacro('default', 'var1 = 123, $var2 => "nette framework"', '')->openingCode);
+	Assert::same("<?php extract(['var1' => 123, 'var2' => \"nette framework\"], EXTR_SKIP) ?>", @$compiler->expandMacro('default', 'var1 = 123, $var2 => "nette framework"', '')->openingCode); // @ deprecated syntax
+	Assert::same("<?php extract(['var1' => 123, 'var2' => \"nette framework\"], EXTR_SKIP) ?>", $compiler->expandMacro('default', '$var1 = 123, $var2 = "nette framework"', '')->openingCode);
 
 	Assert::exception(function () use ($compiler) {
 		$compiler->expandMacro('default', '$temp->var1 = 123', '');

--- a/tests/Latte/CoreMacros.varType.phpt
+++ b/tests/Latte/CoreMacros.varType.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Test: {varType}
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$latte = new Latte\Engine;
+$latte->setLoader(new Latte\Loaders\StringLoader);
+
+Assert::exception(function () use ($latte) {
+	$latte->compile('{varType}');
+}, Latte\CompileException::class, 'Unexpected content%a%');
+
+Assert::exception(function () use ($latte) {
+	$latte->compile('{varType type}');
+}, Latte\CompileException::class, 'Unexpected content%a%');
+
+Assert::exception(function () use ($latte) {
+	$latte->compile('{varType type var}');
+}, Latte\CompileException::class, 'Unexpected content%a%');
+
+Assert::exception(function () use ($latte) {
+	$latte->compile('{varType $var type}');
+}, Latte\CompileException::class, 'Unexpected content%a%');
+
+Assert::noError(function () use ($latte) {
+	$latte->compile('{varType type $var}');
+});

--- a/tests/Latte/FilterExecutor.phpt
+++ b/tests/Latte/FilterExecutor.phpt
@@ -6,6 +6,7 @@
 
 declare(strict_types=1);
 
+use Latte\Runtime\Defaults;
 use Latte\Runtime\FilterExecutor;
 use Latte\Runtime\FilterInfo;
 use Latte\Runtime\Html;
@@ -31,10 +32,15 @@ class MyFilter
 
 
 test(function () {
-	$filters = new FilterExecutor;
+	$filters = new FilterExecutor((new Defaults)->getFilters());
 
 	Assert::true(count($filters->getAll()) > 28);
 	Assert::same('upper', $filters->getAll()['upper']);
+});
+
+
+test(function () {
+	$filters = new FilterExecutor;
 
 	$filters->add('f1', 'strtoupper');
 	Assert::same('strtoupper', $filters->f1);

--- a/tests/Latte/Filters.batch().phpt
+++ b/tests/Latte/Filters.batch().phpt
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Test: Latte\Runtime\Filters::batch()
+ */
+
+declare(strict_types=1);
+
+use Latte\Runtime\Filters;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::type(Generator::class, Filters::batch([], 1));
+
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], -1))
+);
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], 0))
+);
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], 1))
+);
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], 2))
+);
+
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], -1, 'fill'))
+);
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], 0, 'fill'))
+);
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], 1, 'fill'))
+);
+Assert::same(
+	[],
+	iterator_to_array(Filters::batch([], 2, 'fill'))
+);
+
+Assert::same(
+	[['a']],
+	iterator_to_array(Filters::batch(['a'], -1))
+);
+Assert::same(
+	[['a']],
+	iterator_to_array(Filters::batch(['a'], 0))
+);
+Assert::same(
+	[['a']],
+	iterator_to_array(Filters::batch(['a'], 1))
+);
+Assert::same(
+	[['a']],
+	iterator_to_array(Filters::batch(['a'], 2))
+);
+
+Assert::same(
+	[['a']],
+	iterator_to_array(Filters::batch(['a'], -1, 'fill'))
+);
+Assert::same(
+	[['a']],
+	iterator_to_array(Filters::batch(['a'], 0, 'fill'))
+);
+Assert::same(
+	[['a']],
+	iterator_to_array(Filters::batch(['a'], 1, 'fill'))
+);
+Assert::same(
+	[['a', 'fill']],
+	iterator_to_array(Filters::batch(['a'], 2, 'fill'))
+);
+
+Assert::same(
+	[['a'], [1 => 'b'], [2 => 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 0))
+);
+Assert::same(
+	[['a'], [1 => 'b'], [2 => 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 1))
+);
+Assert::same(
+	[['a', 'b'], [2 => 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 2))
+);
+Assert::same(
+	[['a', 'b', 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 3))
+);
+Assert::same(
+	[['a', 'b', 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 4))
+);
+
+Assert::same(
+	[['a'], [1 => 'b'], [2 => 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 0, 'fill'))
+);
+Assert::same(
+	[['a'], [1 => 'b'], [2 => 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 1, 'fill'))
+);
+Assert::same(
+	[['a', 'b'], [2 => 'c', 'fill']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 2, 'fill'))
+);
+Assert::same(
+	[['a', 'b', 'c']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 3, 'fill'))
+);
+Assert::same(
+	[['a', 'b', 'c', 'fill']],
+	iterator_to_array(Filters::batch(['a', 'b', 'c'], 4, 'fill'))
+);
+
+Assert::same(
+	[['a' => 'a', 'b' => 'b'], ['c' => 'c']],
+	iterator_to_array(Filters::batch(['a' => 'a', 'b' => 'b', 'c' => 'c'], 2))
+);
+Assert::same(
+	[['a' => 'a', 'b' => 'b'], ['c' => 'c', 0 => 'fill']],
+	iterator_to_array(Filters::batch(['a' => 'a', 'b' => 'b', 'c' => 'c'], 2, 'fill'))
+);

--- a/tests/Latte/Filters.escapeHtml().phpt
+++ b/tests/Latte/Filters.escapeHtml().phpt
@@ -13,7 +13,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-class Test implements Latte\Runtime\IHtmlString
+class Test implements Latte\Runtime\HtmlString
 {
 	public function __toString(): string
 	{

--- a/tests/Latte/Filters.escapeHtmlText().phpt
+++ b/tests/Latte/Filters.escapeHtmlText().phpt
@@ -13,7 +13,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-class Test implements Latte\Runtime\IHtmlString
+class Test implements Latte\Runtime\HtmlString
 {
 	public function __toString(): string
 	{

--- a/tests/Latte/Filters.escapeJs().phpt
+++ b/tests/Latte/Filters.escapeJs().phpt
@@ -13,7 +13,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-class Test implements Latte\Runtime\IHtmlString
+class Test implements Latte\Runtime\HtmlString
 {
 	public function __toString(): string
 	{

--- a/tests/Latte/PhpWriter.formatArgs().phpt
+++ b/tests/Latte/PhpWriter.formatArgs().phpt
@@ -141,6 +141,7 @@ test(function () { // optionalChainingPass
 	Assert::same('$a', formatArgs('$a'));
 	Assert::same('($a ?? null)', formatArgs('$a?'));
 	Assert::same('(($a ?? null))', formatArgs('($a?)'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : $_tmp[1])', formatArgs('$foo?[1]'));
 	Assert::same('$var->prop->elem[1]->call(2)->item', formatArgs('$var->prop->elem[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var ?? null) === null ? null : (($_tmp = $_tmp->prop ?? null) === null ? null : (($_tmp = $_tmp->elem[1] ?? null) === null ? null : (($_tmp = $_tmp->call(2) ?? null) === null ? null : ($_tmp->item ?? null)))))', formatArgs('$var?->prop?->elem[1]?->call(2)?->item?'));
 });

--- a/tests/Latte/PhpWriter.formatArgs().phpt
+++ b/tests/Latte/PhpWriter.formatArgs().phpt
@@ -66,10 +66,6 @@ test(function () { // short ternary operators
 	Assert::same('$c ?: ($a ?: $b)', formatArgs('$c ?: ($a ?: $b)'));
 	Assert::same('$c ? ($a ?: $b) : null', formatArgs('$c ? ($a ?: $b)'));
 	Assert::same('$a ?(1) : null', formatArgs('$a?(1)')); // with braces
-
-	Assert::error(function () {
-		Assert::same('$a ?[1] : null', formatArgs('$a?[1]')); // missing braces
-	}, E_USER_DEPRECATED, 'Short ternary operator requires parentheses around array in $a ?[1]');
 });
 
 

--- a/tests/Latte/PhpWriter.formatModifiers().phpt
+++ b/tests/Latte/PhpWriter.formatModifiers().phpt
@@ -70,6 +70,7 @@ test(function () { // depth
 test(function () { // optionalChainingPass
 	Assert::same('($this->filters->mod)(@, ($a ?? null))', formatModifiers('@', 'mod:$a?'));
 	Assert::same('($this->filters->mod)(@, (($a ?? null)))', formatModifiers('@', 'mod:($a?)'));
+	Assert::same('($this->filters->mod)(@, (($_tmp = $foo ?? null) === null ? null : $_tmp[1]))', formatModifiers('@', 'mod:$foo?[1]'));
 	Assert::same('($this->filters->mod)(@, (($_tmp = $var ?? null) === null ? null : (($_tmp = $_tmp->prop ?? null) === null ? null : (($_tmp = $_tmp->elem[1] ?? null) === null ? null : (($_tmp = $_tmp->call(2) ?? null) === null ? null : ($_tmp->item ?? null))))))', formatModifiers('@', 'mod:$var?->prop?->elem[1]?->call(2)?->item?'));
 });
 

--- a/tests/Latte/PhpWriter.optionalChainingPass().phpt
+++ b/tests/Latte/PhpWriter.optionalChainingPass().phpt
@@ -22,8 +22,15 @@ test(function () {
 	Assert::same('($a ?? null)', optionalChaining('$a?'));
 	Assert::same('(($a ?? null))', optionalChaining('($a?)'));
 	Assert::same('a?', optionalChaining('a?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : $_tmp[1])', optionalChaining('$foo?[1]'));
 	Assert::same('($foo[1] ?? null)', optionalChaining('$foo[1]?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[1] ?? null))', optionalChaining('$foo?[1]?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[1] ?? null)) + 10', optionalChaining('$foo?[1]? + 10'));
 	Assert::same('(($foo[1] ?? null))', optionalChaining('($foo[1]?)'));
+	Assert::same('((($_tmp = $foo ?? null) === null ? null : $_tmp[1]))', optionalChaining('($foo?[1])'));
+	Assert::same('[(($_tmp = $foo ?? null) === null ? null : ($_tmp[1] ?? null))]', optionalChaining('[$foo?[1]?]'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[ ($a ?? null) ] ?? null))', optionalChaining('$foo?[ $a? ]?'));
+	Assert::same('(($_tmp = $foo ?? null) === null ? null : ($_tmp[ (($_tmp = $a ?? null) === null ? null : ($_tmp[2] ?? null)) ] ?? null))', optionalChaining('$foo?[ $a?[2]? ]?'));
 
 	Assert::same('(($_tmp = $foo ?? null) === null ? null : $_tmp->prop)', optionalChaining('$foo?->prop'));
 	Assert::same('($foo->prop ?? null)', optionalChaining('$foo->prop?'));
@@ -50,17 +57,20 @@ test(function () {
 	Assert::same('$var->prop->elem[1]->call(2)->item', optionalChaining('$var->prop->elem[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var ?? null) === null ? null : $_tmp->prop->elem[1]->call(2)->item)', optionalChaining('$var?->prop->elem[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var->prop ?? null) === null ? null : $_tmp->elem[1]->call(2)->item)', optionalChaining('$var->prop?->elem[1]->call(2)->item'));
+	Assert::same('(($_tmp = $var->prop->elem ?? null) === null ? null : $_tmp[1]->call(2)->item)', optionalChaining('$var->prop->elem?[1]->call(2)->item'));
 	Assert::same('(($_tmp = $var->prop->elem[1] ?? null) === null ? null : $_tmp->call(2)->item)', optionalChaining('$var->prop->elem[1]?->call(2)->item'));
 	Assert::same('(($_tmp = $var->prop->elem[1]->call(2) ?? null) === null ? null : $_tmp->item)', optionalChaining('$var->prop->elem[1]->call(2)?->item'));
 	Assert::same('($var->prop->elem[1]->call(2)->item ?? null)', optionalChaining('$var->prop->elem[1]->call(2)->item?'));
+	Assert::same(
+		'(($_tmp = $var ?? null) === null ? null : (($_tmp = $_tmp->prop ?? null) === null ? null : (($_tmp = $_tmp->elem ?? null) === null ? null : (($_tmp = $_tmp[1] ?? null) === null ? null : (($_tmp = $_tmp->call(2) ?? null) === null ? null : ($_tmp->item ?? null))))))',
+		optionalChaining('$var?->prop?->elem?[1]?->call(2)?->item?')
+	);
 });
 
 
 test(function () { // not allowed
 	Assert::same('$foo ?(hello)', optionalChaining('$foo?(hello)'));
 	Assert::same('$foo->foo ?(hello)', optionalChaining('$foo->foo?(hello)'));
-
-	Assert::same('$foo ?[1]', optionalChaining('$foo?[1]')); // not allowed due to collision with short ternary
 });
 
 

--- a/tests/Latte/TemplatePrinter.phpt
+++ b/tests/Latte/TemplatePrinter.phpt
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$latte = new Latte\Engine;
+$latte->setLoader(new Latte\Loaders\StringLoader);
+$latte->addFunction('Abc', function (stdClass $a, $b = 132) {});
+
+
+$template = $latte->createTemplate('', ['int' => 123, 'unknown' => null]);
+
+$printer = new Latte\Runtime\TemplatePrinter;
+$class = $printer->print($template);
+
+Assert::type(Nette\PhpGenerator\PhpNamespace::class, $class);
+
+if (PHP_VERSION_ID >= 70400) {
+	Assert::match(
+'/**
+ * @property int $int
+ * @property mixed $unknown
+ * @method mixed Abc(stdClass $a, $b = 132)
+ */
+class Template
+{
+	public int $int;
+
+	public $unknown;
+}',
+		(string) $class
+	);
+
+} else {
+	Assert::match(
+'/**
+ * @property int $int
+ * @property mixed $unknown
+ * @method mixed Abc(stdClass $a, $b = 132)
+ */
+class Template
+{
+	/** @var int */
+	public $int;
+
+	/** @var mixed */
+	public $unknown;
+}',
+		(string) $class
+	);
+}

--- a/tests/Latte/mocks/SnippetBridge.php
+++ b/tests/Latte/mocks/SnippetBridge.php
@@ -18,19 +18,19 @@ class SnippetBridgeMock implements Latte\Runtime\SnippetBridge
 	}
 
 
-	public function setSnippetMode($snippetMode)
+	public function setSnippetMode(bool $snippetMode)
 	{
 		$this->snippetMode = $snippetMode;
 	}
 
 
-	public function needsRedraw($name): bool
+	public function needsRedraw(string $name): bool
 	{
 		return $this->invalid === true || isset($this->invalid[$name]);
 	}
 
 
-	public function markRedrawn($name): void
+	public function markRedrawn(string $name): void
 	{
 		if ($this->invalid !== true) {
 			unset($this->invalid[$name]);
@@ -38,13 +38,13 @@ class SnippetBridgeMock implements Latte\Runtime\SnippetBridge
 	}
 
 
-	public function getHtmlId($name): string
+	public function getHtmlId(string $name): string
 	{
 		return $name;
 	}
 
 
-	public function addSnippet($name, $content): void
+	public function addSnippet(string $name, string $content): void
 	{
 		$this->payload[$name] = $content;
 	}

--- a/tests/Latte/mocks/SnippetBridge.php
+++ b/tests/Latte/mocks/SnippetBridge.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 
-class SnippetBridgeMock implements Latte\Runtime\ISnippetBridge
+class SnippetBridgeMock implements Latte\Runtime\SnippetBridge
 {
 	public $snippetMode = true;
 

--- a/tests/Latte/templates/general.latte
+++ b/tests/Latte/templates/general.latte
@@ -109,10 +109,10 @@ var prop2 = {$people};
 
 
 {default $varx = 2}{$varx}
-{default varx => 4}{$varx}
+{default $varx = 4}{$varx}
 
-{var varx => 8}{$varx}
-{var $varx => 9}{$varx}
+{var $varx = 8}{$varx}
+{var $varx = 9}{$varx}
 
 {var $now = new DateTime}
 {var $foo = $now->format('u')}


### PR DESCRIPTION
- bug fix / new feature? modernize code
- BC break? no
- doc PR: nette/docs? -  

Package is now require PHP 7, which know strict mode `json_encode()`. This PR swich old error hunting to using strict `json_encode()`. 

To keep BC is native `\JsonException` translated to `\RuntimeException` with same value of `$message` and `$code`.

## Tests result
- All tests passed without error.
- PhpStan found 17 errors, but same errors on `master` and this PR – this PR didn't break anything.