### PR TITLE
Filters: fix escaping of IHtmlString from nette/utils

### DIFF
--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -44,7 +44,7 @@ class Filters
 	 */
 	public static function escapeHtmlText($s): string
 	{
-		return $s instanceof HtmlString || $s instanceof \Nette\Utils\HtmlString
+		return $s instanceof HtmlString || $s instanceof \Nette\Utils\IHtmlString
 			? $s->__toString(true)
 			: htmlspecialchars((string) $s, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 	}
@@ -158,7 +158,7 @@ class Filters
 	 */
 	public static function escapeJs($s): string
 	{
-		if ($s instanceof HtmlString || $s instanceof \Nette\Utils\HtmlString) {
+		if ($s instanceof HtmlString || $s instanceof \Nette\Utils\IHtmlString) {
 			$s = $s->__toString(true);
 		}
 

--- a/tests/Latte/expected/macros.general.html.html
+++ b/tests/Latte/expected/macros.general.html.html
@@ -6,7 +6,7 @@
 	<li>Escaped expression: &lt;b&gt;hello&lt;/b&gt;</li>
 	<li>Non-escaped expression: <b>hello</b></li>
 	<li>Array access: Mary</li>
-	<li>Html: <div title='1/2"'></div></li>
+	<li>Html: <div title='1/2"'></div> <span title='/"'>foo</span></li>
 	<li>Translated: yraM</li>
 	<li>Translated string: joha</li>
 	<li>Non-escaped and translated: yraM</li>
@@ -70,7 +70,7 @@ var prop = ["John","Mary","Paul","]]\x3E \x3C!--"];
 
 document.getElementById("some&<>\"'\/chars").style.backgroundColor = 'red';
 
-var html = "<div title='1\/2\"'><\/div>";
+var html = "<div title='1\/2\"'><\/div>" || "<span title='\/\"'>foo<\/span>";
 -->
 </script>
 
@@ -91,7 +91,7 @@ var prop2 = ["John","Mary","Paul","]]\x3E \x3C!--"];
  "color:some\&amp;\&lt;\&gt;\&quot;\&apos;\/chars;"
  rel="some&amp;&lt;&gt;&quot;&apos;/chars"
  onblur="alert(&quot;some&amp;&lt;&gt;\&quot;&apos;\/chars&quot;)"
- alt='&lt;div title=&apos;1/2&quot;&apos;&gt;&lt;/div&gt;'
+ alt='&lt;div title=&apos;1/2&quot;&apos;&gt;&lt;/div&gt; &lt;span title=&apos;/&quot;&apos;&gt;foo&lt;/span&gt;'
  onfocus="alert(&quot;&lt;div title=&apos;1\/2\&quot;&apos;&gt;&lt;\/div&gt;&quot;)"
 >click on me some&amp;&lt;&gt;"'/chars</p>
 

--- a/tests/Latte/expected/macros.general.html.phtml
+++ b/tests/Latte/expected/macros.general.html.phtml
@@ -24,7 +24,7 @@ class Template%a% extends Latte\Runtime\Template
 	<li>Escaped expression: <?php echo LR\Filters::escapeHtmlText('<' . 'b' . '>hello' . '</b>') /* line 6 */ ?></li>
 	<li>Non-escaped expression: <?php echo '<' . 'b' . '>hello' . '</b>' /* line 7 */ ?></li>
 	<li>Array access: <?php echo LR\Filters::escapeHtmlText($people[1]) /* line 8 */ ?></li>
-	<li>Html: <?php echo LR\Filters::escapeHtmlText($el) /* line 9 */ ?></li>
+	<li>Html: <?php echo LR\Filters::escapeHtmlText($el) /* line 9 */ ?> <?php echo LR\Filters::escapeHtmlText($el2) /* line 9 */ ?></li>
 	<li>Translated: <?php echo LR\Filters::escapeHtmlText(($this->filters->translate)($people[1])) ?></li>
 	<li>Translated string: <?php echo LR\Filters::escapeHtmlText(($this->filters->translate)('ahoj')) ?></li>
 	<li>Non-escaped and translated: <?php echo ($this->filters->translate)($people[1]) ?></li>
@@ -130,7 +130,7 @@ var prop = <?php echo LR\Filters::escapeJs($people) /* line 70 */ ?>;
 
 document.getElementById(<?php echo LR\Filters::escapeJs($xss) /* line 72 */ ?>).style.backgroundColor = 'red';
 
-var html = <?php echo LR\Filters::escapeJs($el) /* line 74 */ ?>;
+var html = <?php echo LR\Filters::escapeJs($el) /* line 74 */ ?> || <?php echo LR\Filters::escapeJs($el2) /* line 74 */ ?>;
 -->
 </script>
 
@@ -151,7 +151,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
  "color:<?php echo LR\Filters::escapeHtmlAttr(LR\Filters::escapeCss($xss)) /* line 92 */ ?>;"
  rel="<?php echo LR\Filters::escapeHtmlAttr($xss) /* line 93 */ ?>"
  onblur="alert(<?php echo LR\Filters::escapeHtmlAttr(LR\Filters::escapeJs($xss)) /* line 94 */ ?>)"
- alt='<?php echo LR\Filters::escapeHtmlAttr($el) /* line 95 */ ?>'
+ alt='<?php echo LR\Filters::escapeHtmlAttr($el) /* line 95 */ ?> <?php echo LR\Filters::escapeHtmlAttr($el2) /* line 95 */ ?>'
  onfocus="alert(<?php echo LR\Filters::escapeHtmlAttr(LR\Filters::escapeJs($el)) /* line 96 */ ?>)"
 >click on me <?php echo LR\Filters::escapeHtmlText($xss) /* line 97 */ ?></p>
 

--- a/tests/Latte/expected/macros.general.xhtml.html
+++ b/tests/Latte/expected/macros.general.xhtml.html
@@ -6,7 +6,7 @@
 	<li>Escaped expression: &lt;b&gt;hello&lt;/b&gt;</li>
 	<li>Non-escaped expression: <b>hello</b></li>
 	<li>Array access: Mary</li>
-	<li>Html: <div title='1/2"'></div></li>
+	<li>Html: <div title='1/2"'></div> <span title='/"'>foo</span></li>
 	<li>Translated: yraM</li>
 	<li>Translated string: joha</li>
 	<li>Non-escaped and translated: yraM</li>
@@ -70,7 +70,7 @@ var prop = ["John","Mary","Paul","]]\x3E \x3C!--"];
 
 document.getElementById("some&<>\"'\/chars").style.backgroundColor = 'red';
 
-var html = "<div title='1\/2\"'><\/div>";
+var html = "<div title='1\/2\"'><\/div>" || "<span title='\/\"'>foo<\/span>";
 -->
 </script>
 
@@ -91,7 +91,7 @@ var prop2 = ["John","Mary","Paul","]]\x3E \x3C!--"];
  "color:some\&amp;\&lt;\&gt;\&quot;\&apos;\/chars;"
  rel="some&amp;&lt;&gt;&quot;&apos;/chars"
  onblur="alert(&quot;some&amp;&lt;&gt;\&quot;&apos;\/chars&quot;)"
- alt='&lt;div title=&apos;1/2&quot;&apos;&gt;&lt;/div&gt;'
+ alt='&lt;div title=&apos;1/2&quot;&apos;&gt;&lt;/div&gt; &lt;span title=&apos;/&quot;&apos;&gt;foo&lt;/span&gt;'
  onfocus="alert(&quot;&lt;div title=&apos;1\/2\&quot;&apos;&gt;&lt;\/div&gt;&quot;)"
 >click on me some&amp;&lt;&gt;"'/chars</p>
 

--- a/tests/Latte/expected/macros.general.xhtml.phtml
+++ b/tests/Latte/expected/macros.general.xhtml.phtml
@@ -26,7 +26,7 @@ class Template%a% extends Latte\Runtime\Template
 	<li>Escaped expression: <?php echo LR\Filters::escapeHtmlText('<' . 'b' . '>hello' . '</b>') /* line 6 */ ?></li>
 	<li>Non-escaped expression: <?php echo '<' . 'b' . '>hello' . '</b>' /* line 7 */ ?></li>
 	<li>Array access: <?php echo LR\Filters::escapeHtmlText($people[1]) /* line 8 */ ?></li>
-	<li>Html: <?php echo LR\Filters::escapeHtmlText($el) /* line 9 */ ?></li>
+	<li>Html: <?php echo LR\Filters::escapeHtmlText($el) /* line 9 */ ?> <?php echo LR\Filters::escapeHtmlText($el2) /* line 9 */ ?></li>
 	<li>Translated: <?php echo LR\Filters::escapeHtmlText(($this->filters->translate)($people[1])) ?></li>
 	<li>Translated string: <?php echo LR\Filters::escapeHtmlText(($this->filters->translate)('ahoj')) ?></li>
 	<li>Non-escaped and translated: <?php echo ($this->filters->translate)($people[1]) ?></li>
@@ -132,7 +132,7 @@ var prop = <?php echo LR\Filters::escapeJs($people) /* line 70 */ ?>;
 
 document.getElementById(<?php echo LR\Filters::escapeJs($xss) /* line 72 */ ?>).style.backgroundColor = 'red';
 
-var html = <?php echo LR\Filters::escapeJs($el) /* line 74 */ ?>;
+var html = <?php echo LR\Filters::escapeJs($el) /* line 74 */ ?> || <?php echo LR\Filters::escapeJs($el2) /* line 74 */ ?>;
 -->
 </script>
 
@@ -153,7 +153,7 @@ var prop2 = <?php echo LR\Filters::escapeJs($people) /* line 82 */ ?>;
  "color:<?php echo LR\Filters::escapeHtmlAttr(LR\Filters::escapeCss($xss)) /* line 92 */ ?>;"
  rel="<?php echo LR\Filters::escapeHtmlAttr($xss) /* line 93 */ ?>"
  onblur="alert(<?php echo LR\Filters::escapeHtmlAttr(LR\Filters::escapeJs($xss)) /* line 94 */ ?>)"
- alt='<?php echo LR\Filters::escapeHtmlAttr($el) /* line 95 */ ?>'
+ alt='<?php echo LR\Filters::escapeHtmlAttr($el) /* line 95 */ ?> <?php echo LR\Filters::escapeHtmlAttr($el2) /* line 95 */ ?>'
  onfocus="alert(<?php echo LR\Filters::escapeHtmlAttr(LR\Filters::escapeJs($el)) /* line 96 */ ?>)"
 >click on me <?php echo LR\Filters::escapeHtmlText($xss) /* line 97 */ ?></p>
 

--- a/tests/Latte/macros.general.html.phpt
+++ b/tests/Latte/macros.general.html.phpt
@@ -23,6 +23,7 @@ $params['mxss'] = '`mxss';
 $params['people'] = ['John', 'Mary', 'Paul', ']]> <!--'];
 $params['menu'] = ['about', ['product1', 'product2'], 'contact'];
 $params['el'] = new Html("<div title='1/2\"'></div>");
+$params['el2'] = \Nette\Utils\Html::el('span', ['title' => '/"'])->setText('foo');
 
 Assert::matchFile(
 	__DIR__ . '/expected/macros.general.html.phtml',

--- a/tests/Latte/macros.general.xhtml.phpt
+++ b/tests/Latte/macros.general.xhtml.phpt
@@ -24,6 +24,7 @@ $params['mxss'] = '`mxss';
 $params['people'] = ['John', 'Mary', 'Paul', ']]> <!--'];
 $params['menu'] = ['about', ['product1', 'product2'], 'contact'];
 $params['el'] = new Html("<div title='1/2\"'></div>");
+$params['el2'] = \Nette\Utils\Html::el('span', ['title' => '/"'])->setText('foo');
 
 Assert::matchFile(
 	__DIR__ . '/expected/macros.general.xhtml.phtml',

--- a/tests/Latte/templates/general.latte
+++ b/tests/Latte/templates/general.latte
@@ -6,7 +6,7 @@
 	<li>Escaped expression: {='<' . 'b' . '>hello' . '</b>'}</li>
 	<li>Non-escaped expression: {='<' . 'b' . '>hello' . '</b>'|noescape}</li>
 	<li>Array access: {$people[1]}</li>
-	<li>Html: {$el}</li>
+	<li>Html: {$el} {$el2}</li>
 	<li>Translated: {_$people[1]}</li>
 	<li>Translated string: {_ahoj}</li>
 	<li>Non-escaped and translated: {_$people[1]|noescape}</li>
@@ -71,7 +71,7 @@ var prop = {$people};
 
 document.getElementById({$xss}).style.backgroundColor = 'red';
 
-var html = {$el};
+var html = {$el} || {$el2};
 -->
 </script>
 
@@ -92,7 +92,7 @@ var prop2 = {$people};
  "color:{$xss};"
  rel="{$xss}"
  onblur="alert({$xss})"
- alt='{$el}'
+ alt='{$el} {$el2}'
  onfocus="alert({$el})"
 >click on me {$xss}</p>
 


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: not needed

435139bf5b75f811ffef3e79cc84d4170a7946d0 broke compatibility with nette/utils - this package still uses `I` prefix on interfaces, namely there is `HtmlString` interface, it's still called `IHtmlString`.