### PR TITLE
<script type="module"> is also javascript context

### DIFF
--- a/src/Latte/Compiler/Compiler.php
+++ b/src/Latte/Compiler/Compiler.php
@@ -437,7 +437,7 @@ class Compiler
 
 		} elseif (
 			(($lower = strtolower($htmlNode->name)) === 'script' || $lower === 'style')
-			&& (!isset($htmlNode->attrs['type']) || preg_match('#(java|j|ecma|live)script|json|css#i', $htmlNode->attrs['type']))
+			&& (!isset($htmlNode->attrs['type']) || preg_match('#(java|j|ecma|live)script|module|json|css#i', $htmlNode->attrs['type']))
 		) {
 			$this->context = $lower === 'script' ? self::CONTEXT_HTML_JS : self::CONTEXT_HTML_CSS;
 		}


### PR DESCRIPTION
<script type="module">//…</script> would by also be Javascript context ( Compiler::CONTEXT_HTML_JS )

attribute type="module" on script elementy is necessary for using dynamic javascript import ( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import )
