### PR TITLE
linter: Add shebang so it can be run directly

### DIFF
--- a/bin/latte-lint
+++ b/bin/latte-lint
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 declare(strict_types=1);
@@ -32,7 +33,7 @@ Latte linter
 ';
 
 if ($argc < 2) {
-	echo "Usage: php latte-lint <path>\n";
+	echo "Usage: latte-lint <path>\n";
 	exit(1);
 }
 


### PR DESCRIPTION
- BC break? no
- new feature? yes but tiny

Hi, I was happy to see linter added ❤ but when I ran it like this:

```
$ vendor/latte/latte/bin/latte-lint
```

I got 
```
vendor/latte/latte/bin/latte-lint: line 1: ?php: No such file or directory
```
because I didn't run it like (omitted `php` because I didn't expect it needs to be added)
```
$ php vendor/latte/latte/bin/latte-lint
```

This PR adds a shebang line to `latte-lint` so it can be executed directly without `php` in the command line.
Also the executable flag is added to the script.

This is in line with other similar tools (like for example `tester`).

Thanks!