### PR TITLE
feat: allow use of text/plain for script tag

### DIFF
--- a/src/Latte/Compiler/Nodes/Html/TagNode.php
+++ b/src/Latte/Compiler/Nodes/Html/TagNode.php
@@ -93,7 +93,7 @@ class TagNode extends Node
 			!$this->closing && !$this->selfClosing
 			&& ($name === 'script' || $name === 'style')
 			&& is_string($attr = $this->getAttribute('type') ?? 'css')
-			&& preg_match('#(java|j|ecma|live)script|module|json|css#i', $attr)
+			&& preg_match('#(java|j|ecma|live)script|module|json|css|plain#i', $attr)
 		) {
 			return $name === 'script'
 				? Compiler::CONTEXT_HTML_JS


### PR DESCRIPTION
- bug fix / new feature?   <!-- #issue numbers, if any -->
- BC break? yes
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

For GDPR usage most scripts must be set as `text/plain`, but latte doesn't handle types in variables with this type.

eg. here - https://orestbida.com/demo-projects/cookieconsent/

This PR fixes it, but might cause bc break, if anyone used the `text/plain` and inserted quotes manualy

eg.
`Do not place {$test} inside quotes in .../templates/@layout.latte:20`

But this change is definitely needed, because if you would want to make the cookieconsent for scripts conditional, there would be problems with the js variables being or not being processed with latte.
