### PR TITLE
Statical analysis for Latte [WIP]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,8 @@
 parameters:
+	excludePaths:
+		analyse:
+			- src/Latte/Compiler/TagParser.php
+
 	level: 5
 
 	paths:

--- a/src/Latte/Compiler/Block.php
+++ b/src/Latte/Compiler/Block.php
@@ -26,6 +26,7 @@ final class Block
 
 	/** @var ParameterNode[] */
 	public array $parameters = [];
+	public VariableScope $variables;
 
 
 	public function __construct(

--- a/src/Latte/Compiler/PrintContext.php
+++ b/src/Latte/Compiler/PrintContext.php
@@ -77,10 +77,14 @@ final class PrintContext
 	/** @var Escaper[] */
 	private array $escaperStack = [];
 
+	/** @var VariableScope[] */
+	private array $scopeStack = [];
+
 
 	public function __construct(string $contentType = ContentType::Html)
 	{
 		$this->escaperStack[] = new Escaper($contentType);
+		$this->scopeStack[] = new VariableScope;
 	}
 
 
@@ -160,9 +164,28 @@ final class PrintContext
 	}
 
 
+	public function beginVariableScope(): VariableScope
+	{
+		return $this->scopeStack[] = clone end($this->scopeStack);
+	}
+
+
+	public function restoreVariableScope(): void
+	{
+		array_pop($this->scopeStack);
+	}
+
+
+	public function getVariableScope(): VariableScope
+	{
+		return end($this->scopeStack);
+	}
+
+
 	public function addBlock(Block $block): void
 	{
 		$block->escaping = $this->getEscaper()->export();
+		$block->variables = clone $this->getVariableScope();
 		$block->method = 'block' . ucfirst(trim(preg_replace('#\W+#', '_', $block->name->print($this)), '_'));
 		$lower = strtolower($block->method);
 		$used = $this->blocks + ['block' => 1];

--- a/src/Latte/Compiler/VariableScope.php
+++ b/src/Latte/Compiler/VariableScope.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the Latte (https://latte.nette.org)
+ * Copyright (c) 2008 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Latte\Compiler;
+
+use Latte;
+
+
+final class VariableScope
+{
+	use Latte\Strict;
+
+	/** @var string[] */
+	public array $types = [];
+
+
+	public function addVariable(string $name, ?string $type): string
+	{
+		return $this->types[$name] = $this->printComment($name, $type);
+	}
+
+
+	public function addExpression(Nodes\Php\ExpressionNode $expr, ?Nodes\Php\SuperiorTypeNode $type): string
+	{
+		return $expr instanceof Nodes\Php\Expression\VariableNode && is_string($expr->name)
+			? $this->addVariable($expr->name, $type?->type)
+			: '';
+	}
+
+
+	public static function printComment(string $name, ?string $type): string
+	{
+		if (!$type) {
+			return '';
+		}
+		$str = '@var ' . $type . ' $' . $name;
+		return '/** ' . str_replace('*/', '* /', $str) . ' */';
+	}
+
+
+	public function extractTypes(): string
+	{
+		return implode('', $this->types) . "\n";
+	}
+}

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -191,6 +191,7 @@ class Engine
 			$this->getTemplateClass($name),
 			$comment,
 			$this->strictTypes,
+			$this->getFilters(),
 		);
 	}
 

--- a/src/Latte/Essential/Blueprint.php
+++ b/src/Latte/Essential/Blueprint.php
@@ -95,7 +95,7 @@ final class Blueprint
 	}
 
 
-	private function printType(?string $type, bool $nullable, ?Php\PhpNamespace $namespace): string
+	public static function printType(?string $type, bool $nullable, ?Php\PhpNamespace $namespace): string
 	{
 		if ($type === null) {
 			return '';
@@ -123,7 +123,7 @@ final class Blueprint
 		$list = $function->getParameters();
 		foreach ($list as $param) {
 			$variadic = $function->isVariadic() && $param === end($list);
-			$params[] = ltrim($this->printType($param->getType(), $param->isNullable(), $namespace) . ' ')
+			$params[] = ltrim(self::printType($param->getType(), $param->isNullable(), $namespace) . ' ')
 				. ($param->isReference() ? '&' : '')
 				. ($variadic ? '...' : '')
 				. '$' . $param->getName()

--- a/src/Latte/Essential/Nodes/ForeachNode.php
+++ b/src/Latte/Essential/Nodes/ForeachNode.php
@@ -88,6 +88,12 @@ class ForeachNode extends StatementNode
 
 	public function print(PrintContext $context): string
 	{
+		$scope = $context->getVariableScope();
+		if ($this->key) {
+			$scope->addExpression($this->key, null);
+		}
+		$scope->addExpression($this->value, null);
+
 		$content = $this->content->print($context);
 		$iterator = $this->else || ($this->iterator ?? preg_match('#\$iterator\W|\Wget_defined_vars\W#', $content));
 

--- a/src/Latte/Essential/Nodes/VarTypeNode.php
+++ b/src/Latte/Essential/Nodes/VarTypeNode.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Latte\Essential\Nodes;
 
+use Latte\Compiler\Nodes\Php\Expression\VariableNode;
+use Latte\Compiler\Nodes\Php\SuperiorTypeNode;
 use Latte\Compiler\Nodes\StatementNode;
 use Latte\Compiler\PrintContext;
 use Latte\Compiler\Tag;
@@ -20,17 +22,36 @@ use Latte\Compiler\Token;
  */
 class VarTypeNode extends StatementNode
 {
+	public VariableNode $variable;
+	public SuperiorTypeNode $type;
+
+
 	public static function create(Tag $tag): static
 	{
 		$tag->expectArguments();
-		$tag->parser->parseType();
-		$tag->parser->stream->consume(Token::Php_Variable);
-		return new static;
+		$type = $tag->parser->parseType();
+		if (!$type) {
+			$tag->parser->stream->throwUnexpectedException();
+		}
+		$token = $tag->parser->stream->consume(Token::Php_Variable);
+
+		$node = new static;
+		$node->type = $type;
+		$node->variable = new VariableNode(substr($token->text, 1));
+		return $node;
 	}
 
 
 	public function print(PrintContext $context): string
 	{
-		return '';
+		$scope = $context->getVariableScope();
+		return $scope->addExpression($this->variable, $this->type) . "\n";
+	}
+
+
+	public function &getIterator(): \Generator
+	{
+		yield $this->variable;
+		yield $this->type;
 	}
 }

--- a/tests/tags/templateType.phpt
+++ b/tests/tags/templateType.phpt
@@ -11,6 +11,17 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
+class TemplateClass
+{
+	public $noType;
+	public int $intType;
+	public int|bool $intBoolType;
+	/** @var array<int, string> */
+	public array $arrayType;
+	private int $private;
+}
+
+
 $latte = new Latte\Engine;
 $latte->setLoader(new Latte\Loaders\StringLoader);
 
@@ -21,9 +32,18 @@ Assert::exception(
 );
 
 Assert::exception(
+	fn() => $latte->compile('{templateType AA\BBB}'),
+	Latte\CompileException::class,
+	"Class 'AA\BBB' used in {templateType} doesn't exist (at column 15)",
+);
+
+Assert::exception(
 	fn() => $latte->compile('{if true}{templateType stdClass}{/if}'),
 	Latte\CompileException::class,
 	'{templateType} is allowed only in template header (at column 10)',
 );
 
-Assert::noError(fn() => $latte->compile('{templateType stdClass}'));
+Assert::contains(
+	'/** @var int $intType *//** @var int|bool $intBoolType *//** @var array<int, string> $arrayType */',
+	$latte->compile('{templateType TemplateClass}'),
+);

--- a/tests/tags/var.default.phpt
+++ b/tests/tags/var.default.phpt
@@ -25,7 +25,7 @@ test('{var ...}', function () use ($latte) {
 	// types
 	Assert::contains('$temp->var1 = 123 /*', $latte->compile('{var int $temp->var1 = 123}'));
 	Assert::contains('$temp->var1 = 123 /*', $latte->compile('{var null|int|string[] $temp->var1 = 123}'));
-	Assert::contains('$var1 = 123; $var2 = \'nette framework\' /*', ws($latte->compile('{var int|string[] $var1 = 123, ?class $var2 = "nette framework"}')));
+	Assert::contains('/** @var int|string[] $var1 */ $var1 = 123; /** @var ?class $var2 */ $var2 = \'nette framework\' /* line 1 */;', ws($latte->compile('{var int|string[] $var1 = 123, ?class $var2 = "nette framework"}')));
 	Assert::contains('$var1 = 123; $var2 = 456 /*', ws($latte->compile('{var A\B $var1 = 123, ?A\B $var2 = 456}')));
 	Assert::contains('$var1 = 123; $var2 = 456 /*', ws($latte->compile('{var \A\B $var1 = 123, ?\A\B $var2 = 456}')));
 

--- a/tests/tags/varType.phpt
+++ b/tests/tags/varType.phpt
@@ -35,13 +35,25 @@ Assert::exception(
 Assert::exception(
 	fn() => $latte->compile('{varType $var type}'),
 	Latte\CompileException::class,
-	"Unexpected 'type', expecting end of tag in {varType} (at column 15)",
+	"Unexpected '\$vartype' (at column 10)",
 );
 
-Assert::noError(fn() => $latte->compile('{varType type $var}'));
+Assert::contains(
+	'/** @var type $var */',
+	$latte->compile('{varType type $var}'),
+);
 
-Assert::noError(fn() => $latte->compile('{varType ?\Nm\Class $var}'));
+Assert::contains(
+	'/** @var ?\Nm\Class $var */',
+	$latte->compile('{varType ?\Nm\Class $var}'),
+);
 
-Assert::noError(fn() => $latte->compile('{varType int|null $var}'));
+Assert::contains(
+	'/** @var int|null $var */',
+	$latte->compile('{varType int|null $var}'),
+);
 
-Assert::noError(fn() => $latte->compile('{varType array{0: int, 1: int} $var}'));
+Assert::contains(
+	'/** @var array{0:int,1:int} $var */',
+	$latte->compile('{varType array{0: int, 1: int} $var}'),
+);


### PR DESCRIPTION
The purpose of this PR is to enable statical analysis of resulting code by analysers like PHPStan, Psalm, etc.

Related #262, #275, #276

First commit propagates known types infomation from `{var type}`, `{varType}`, `{define}`, `{templateType}` and `{parameters}` into compiled PHP code in form of `/** @var type $var */` annotations. 

The second commit propagates filter parameter in the form of `@property` annotations and stub class:

```php
/**
* @property FiltersTemplate4d1f38ae82 $filters
*/
final class Template4d1f38ae82 extends Latte\Runtime\Template
{

	public function main(array $ʟ_args): void
	{
		echo LR\Filters::escapeHtmlText(($this->filters->lower)(($this->filters->upper)($a))) /* line 1 */;
	}
}

/**
* @property callable(mixed): string $lower
* @property callable(mixed): string $upper
*/
class FiltersTemplate4d1f38ae82
{
}
```