### PR TITLE
Add function to the FileLoader to check if a template exists

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,8 @@
 parameters:
+	excludePaths:
+		analyse:
+			- src/Latte/Compiler/TagParser.php
+
 	level: 5
 
 	paths:

--- a/src/Latte/Loaders/FileLoader.php
+++ b/src/Latte/Loaders/FileLoader.php
@@ -49,6 +49,23 @@ class FileLoader implements Latte\Loader
 		return file_get_contents($file);
 	}
 
+	/**
+	 * Returns whether the template exists in the filesystem.
+	 */
+	public function fileExists(string $fileName): bool
+	{
+		$file = $this->baseDir . $fileName;
+		if ($this->baseDir && !str_starts_with($this->normalizePath($file), $this->baseDir)) {
+			return false;
+
+		} elseif (!is_file($file)) {
+			return false;
+
+		}
+
+		return true;
+	}
+
 
 	public function isExpired(string $file, int $time): bool
 	{

--- a/tests/common/Loaders.FileLoader.phpt
+++ b/tests/common/Loaders.FileLoader.phpt
@@ -21,6 +21,9 @@ Assert::true($loader->isExpired(__FILE__, filemtime(__FILE__) - 1));
 
 Assert::true($loader->isExpired('nonexist', filemtime(__FILE__)));
 
+Assert::true($loader->fileExists(__FILE__));
+Assert::false($loader->fileExists('nonexist'));
+
 Assert::same('/a/b/inner', strtr($loader->getReferredName('inner', '/a\\b/c'), '\\', '/'));
 Assert::same('/a/b/c', strtr($loader->getReferredName('/a/b/c', '/a/b/c'), '\\', '/'));
 Assert::same('/a/c', strtr($loader->getReferredName('../c', '/a/b/c'), '\\', '/'));


### PR DESCRIPTION
- new feature: check if template exists
- no breaking changes
- probably doesn't warrant any documentation updates

I have a bit of a unique use-case where it's critical that I check that a template exists (so that I can render a generic template if it doesn't). For example:

```php
$latte->setLoader($file_loader = new Latte\Loaders\FileLoader);

$latte->addFunction('template_exists', function ($filename) use ($file_loader) {
    return $file_loader->fileExists($filename);
});
```

```php
  {if (template_exists("$name.php"))}
    {embed "$name.php"}{/embed}
  {else}
    {embed "generic.php"}{/embed}
  {/if}
```

I see that there is a Loader interface/contract, but I'm assuming that's better left alone (since `fileExists` implies a FileLoader specifically).