### PR TITLE
allow {define} inside {embed}

### DIFF
--- a/src/Latte/Essential/Nodes/EmbedNode.php
+++ b/src/Latte/Essential/Nodes/EmbedNode.php
@@ -56,7 +56,7 @@ class EmbedNode extends StatementNode
 		[$node->blocks] = yield;
 
 		foreach ($node->blocks->children as $child) {
-			if (!$child instanceof ImportNode && !$child instanceof BlockNode && !$child instanceof TextNode) {
+			if (!$child instanceof ImportNode && !$child instanceof DefineNode && !$child instanceof BlockNode && !$child instanceof TextNode) {
 				throw new CompileException('Unexpected content inside {embed} tags.', $child->position);
 			}
 		}


### PR DESCRIPTION
Embed template:

```latte
<form n:name="$form">
	{foreach $form->getComponents() as $component}
		{if $component instanceof Nette\Forms\Container}
			{include container $component->getComponents()}
		{else}
			{include controls $component}
		{/if}
	{/foreach}
</form>

{define container $container}
	{dump $container}
{/define}
```

In latte 2 works following code:
```latte
{embed '~form'}
	{define container $container}
		{dump $container}
	{/define}
{/embed}
```