### PR TITLE
Add ability to set default syntax from Latte\Engine

### DIFF
--- a/src/Latte/Compiler/TemplateParser.php
+++ b/src/Latte/Compiler/TemplateParser.php
@@ -408,6 +408,16 @@ final class TemplateParser
 		return $this->contentType;
 	}
 
+	
+	/**
+	 * Sets tag syntax for lexer
+	 */
+	public function setSyntax(?string $syntax): static
+	{
+		$this->lexer->setSyntax($syntax);
+		return $this;
+	}
+
 
 	/** @internal */
 	public function getStream(): TokenStream

--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -50,6 +50,7 @@ class Engine
 	private bool $sandboxed = false;
 	private ?string $phpBinary = null;
 	private ?string $cacheKey;
+	private ?string $defaultSyntax = null;
 
 
 	public function __construct()
@@ -147,6 +148,9 @@ class Engine
 	public function parse(string $template): TemplateNode
 	{
 		$parser = new Compiler\TemplateParser;
+		if ($this->defaultSyntax) {
+			$parser->setSyntax($this->defaultSyntax);
+		}
 		$parser->strict = $this->strictParsing;
 
 		foreach ($this->extensions as $extension) {
@@ -562,6 +566,15 @@ class Engine
 	public function isStrictParsing(): bool
 	{
 		return $this->strictParsing;
+	}
+	
+	/**
+	 * Sets default tag syntax
+	 */
+	public function setDefaultSyntax(?string $defaultSyntax): static
+	{
+		$this->defaultSyntax = $defaultSyntax;
+		return $this;
 	}
 
 


### PR DESCRIPTION
- bug fix / new feature?   new feature
- BC break? no

Needed to set default syntax to double in my current project. Added function on the Engine level to set the default syntax.

$latte = new Latte\Engine;
$latte->setDefaultSyntax('double');

passes syntax to parser only if set and parser sets $this->lexer->setSyntax();

not too familiar with tests but all the ones I ran passed and my project has been working for a while with this set up.

if I need to supply anything else just let me know.