### PR TITLE
Fix typo in intl-related locale exception message

### DIFF
--- a/src/Latte/Engine.php
+++ b/src/Latte/Engine.php
@@ -572,7 +572,7 @@ class Engine
 	public function setLocale(?string $locale): static
 	{
 		if ($locale && !extension_loaded('intl')) {
-			throw new RuntimeException("Locate requires the 'intl' extension to be installed.");
+			throw new RuntimeException("Setting a locale requires the 'intl' extension to be installed.");
 		}
 		$this->locale = $locale;
 		return $this;


### PR DESCRIPTION
- typo fix
- no
- n/a

Fixed a typo in missing intl extension exception message, made the message a bit more verbal
