### PR TITLE
Update FileLoader.php to work within PHARs on Windows

### DIFF
--- a/src/Latte/Loaders/FileLoader.php
+++ b/src/Latte/Loaders/FileLoader.php
@@ -87,6 +87,7 @@ class FileLoader implements Latte\Loader
 			}
 		}
 
-		return implode(DIRECTORY_SEPARATOR, $res);
+		$res_str = implode(DIRECTORY_SEPARATOR, $res);
+		return (str_starts_with($res_str, 'phar:') ? str_replace(":\\\\","://", $res_str) : $res_str);
 	}
 }

--- a/src/Latte/Sandbox/Nodes/FunctionCallNode.php
+++ b/src/Latte/Sandbox/Nodes/FunctionCallNode.php
@@ -26,6 +26,5 @@ class FunctionCallNode extends Expression\FunctionCallNode
 		return '$this->global->sandbox->call('
 			. $context->memberAsString($this->name) . ', '
 			. $context->argumentsAsArray($this->args) . ')';
-
 	}
 }


### PR DESCRIPTION
Fixed FileLoader::normalizePath so that templates in PHARs on Windows work.

- bug fix #378    <!-- #issue numbers, if any -->
- BC break? no
