### PR TITLE
Stop encoding {{ with empty comment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
     code_coverage:
         name: Code Coverage
         runs-on: ubuntu-latest
+        continue-on-error: true
         steps:
             - uses: actions/checkout@v4
             - uses: shivammathur/setup-php@v2

--- a/src/Latte/Essential/CoreExtension.php
+++ b/src/Latte/Essential/CoreExtension.php
@@ -123,6 +123,7 @@ final class CoreExtension extends Latte\Extension
 			'ceil' => $this->filters->ceil(...),
 			'checkUrl' => $this->filters->checkUrl(...),
 			'clamp' => $this->filters->clamp(...),
+			'column' => $this->filters->column(...),
 			'dataStream' => $this->filters->dataStream(...),
 			'datastream' => $this->filters->dataStream(...),
 			'date' => $this->filters->date(...),

--- a/src/Latte/Essential/CoreExtension.php
+++ b/src/Latte/Essential/CoreExtension.php
@@ -124,6 +124,7 @@ final class CoreExtension extends Latte\Extension
 			'checkUrl' => $this->filters->checkUrl(...),
 			'clamp' => $this->filters->clamp(...),
 			'column' => $this->filters->column(...),
+			'commas' => $this->filters->commas(...),
 			'dataStream' => $this->filters->dataStream(...),
 			'datastream' => $this->filters->dataStream(...),
 			'date' => $this->filters->date(...),

--- a/src/Latte/Essential/CoreExtension.php
+++ b/src/Latte/Essential/CoreExtension.php
@@ -213,7 +213,11 @@ final class CoreExtension extends Latte\Extension
 		return [
 			'internalVariables' => $passes->forbiddenVariablesPass(...),
 			'checkUrls' => $passes->checkUrlsPass(...),
-			'overwrittenVariables' => Nodes\ForeachNode::overwrittenVariablesPass(...),
+			'overwrittenVariables' => function (Latte\Compiler\Nodes\TemplateNode $node): void {
+				if (!$this->engine->hasFeature(Latte\Feature::ScopedLoopVariables)) {
+					Nodes\ForeachNode::overwrittenVariablesPass($node);
+				}
+			},
 			'customFunctions' => $passes->customFunctionsPass(...),
 			'moveTemplatePrintToHead' => Nodes\TemplatePrintNode::moveToHeadPass(...),
 			'nElse' => Nodes\NElseNode::processPass(...),

--- a/src/Latte/Essential/CoreExtension.php
+++ b/src/Latte/Essential/CoreExtension.php
@@ -152,6 +152,7 @@ final class CoreExtension extends Latte\Extension
 			'join' => $this->filters->implode(...),
 			'last' => $this->filters->last(...),
 			'length' => $this->filters->length(...),
+			'limit' => fn(iterable $value, int $length, int $offset = 0) => Filters::slice($value, $offset, $length, preserveKeys: true),
 			'localDate' => $this->filters->localDate(...),
 			'lower' => extension_loaded('mbstring')
 				? $this->filters->lower(...)

--- a/src/Latte/Essential/Filters.php
+++ b/src/Latte/Essential/Filters.php
@@ -146,6 +146,21 @@ final class Filters
 
 
 	/**
+	 * Join array elements with a comma and space.
+	 * @param  string[]  $arr
+	 */
+	public static function commas(array $arr, ?string $lastGlue = null): string
+	{
+		if ($lastGlue === null || count($arr) < 2) {
+			return implode(', ', $arr);
+		}
+
+		$last = array_pop($arr);
+		return implode(', ', $arr) . $lastGlue . $last;
+	}
+
+
+	/**
 	 * Splits a string by a string.
 	 * @return list<string>
 	 */

--- a/src/Latte/Essential/Filters.php
+++ b/src/Latte/Essential/Filters.php
@@ -514,6 +514,17 @@ final class Filters
 
 
 	/**
+	 * Returns the values from a single column in the input array.
+	 * @param  iterable<mixed>  $data
+	 * @return mixed[]
+	 */
+	public static function column(iterable $data, string|int|null $columnKey, string|int|null $indexKey = null): array
+	{
+		return array_column(iterator_to_array($data), $columnKey, $indexKey);
+	}
+
+
+	/**
 	 * Chunks items by returning an array of arrays with the given number of items.
 	 * @param  iterable<mixed>  $list
 	 * @return \Generator<int, array<mixed>>

--- a/src/Latte/Essential/Filters.php
+++ b/src/Latte/Essential/Filters.php
@@ -477,7 +477,7 @@ final class Filters
 	/**
 	 * Pad a string to a certain length with another string.
 	 */
-	public static function padLeft(string|Stringable|null $s, int $length, string $append = ' '): string
+	public static function padLeft(string|Stringable|int|float|null $s, int $length, string $append = ' '): string
 	{
 		$s = (string) $s;
 		$length = max(0, $length - self::strLength($s));
@@ -489,7 +489,7 @@ final class Filters
 	/**
 	 * Pad a string to a certain length with another string.
 	 */
-	public static function padRight(string|Stringable|null $s, int $length, string $append = ' '): string
+	public static function padRight(string|Stringable|int|float|null $s, int $length, string $append = ' '): string
 	{
 		$s = (string) $s;
 		$length = max(0, $length - self::strLength($s));

--- a/src/Latte/Feature.php
+++ b/src/Latte/Feature.php
@@ -21,4 +21,7 @@ enum Feature
 
 	/** Shows warnings for deprecated Latte 3.0 syntax */
 	case MigrationWarnings;
+
+	/** Variables from {foreach} exist only within the loop */
+	case ScopedLoopVariables;
 }

--- a/src/Latte/Runtime/HtmlHelpers.php
+++ b/src/Latte/Runtime/HtmlHelpers.php
@@ -43,7 +43,7 @@ final class HtmlHelpers
 		}
 
 		$s = htmlspecialchars((string) $s, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
-		$s = strtr($s, ['{{' => '{<!-- -->{', '{' => '&#123;']);
+		$s = strtr($s, ['{{' => '&#123;&#123;', '{' => '&#123;']);
 		return $s;
 	}
 

--- a/src/Latte/Sandbox/SecurityPolicy.php
+++ b/src/Latte/Sandbox/SecurityPolicy.php
@@ -62,7 +62,7 @@ class SecurityPolicy implements Latte\Policy
 			'batch', 'breaklines', 'breakLines', 'bytes', 'capitalize', 'ceil', 'clamp', 'date', 'escapeCss', 'escapeHtml',
 			'escapeHtmlComment', 'escapeICal', 'escapeJs', 'escapeUrl', 'escapeXml', 'explode', 'first',
 			'firstUpper', 'floor', 'checkUrl', 'implode', 'indent', 'join', 'last', 'length', 'lower',
-			'number', 'padLeft', 'padRight', 'query', 'random', 'repeat', 'replace', 'replaceRe', 'reverse',
+			'limit', 'number', 'padLeft', 'padRight', 'query', 'random', 'repeat', 'replace', 'replaceRe', 'reverse',
 			'round', 'slice', 'sort', 'spaceless', 'split', 'strip', 'striphtml', 'stripHtml', 'striptags', 'stripTags', 'substr',
 			'trim', 'truncate', 'upper', 'webalize',
 		]);

--- a/tests/common/Helpers.sortBeforeAfter.phpt
+++ b/tests/common/Helpers.sortBeforeAfter.phpt
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test: Latte\Helpers::sortBeforeAfter()
+ */
+
+use Latte\Extension;
+use Latte\Helpers;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// Helper to create ordered item
+$order = fn($before = [], $after = []) => Extension::order(fn() => null, $before, $after);
+
+
+// Test: No constraints - preserve original order
+$list = ['a' => fn() => 1, 'b' => fn() => 2, 'c' => fn() => 3];
+Assert::same(['a', 'b', 'c'], array_keys(Helpers::sortBeforeAfter($list)));
+
+
+// Test: Simple before constraint (c before a)
+$list = ['a' => fn() => 1, 'b' => fn() => 2, 'c' => $order(before: 'a')];
+$result = array_keys(Helpers::sortBeforeAfter($list));
+Assert::true(array_search('c', $result, true) < array_search('a', $result, true), 'c should be before a');
+
+
+// Test: Simple after constraint (a after c)
+$list = ['a' => $order(after: 'c'), 'b' => fn() => 2, 'c' => fn() => 3];
+$result = array_keys(Helpers::sortBeforeAfter($list));
+Assert::true(array_search('a', $result, true) > array_search('c', $result, true), 'a should be after c');
+
+
+// Test: before: '*' (move to start)
+$list = ['a' => fn() => 1, 'b' => fn() => 2, 'c' => $order(before: '*')];
+Assert::same('c', array_keys(Helpers::sortBeforeAfter($list))[0], 'c should be first');
+
+
+// Test: after: '*' (move to end)
+$list = ['a' => $order(after: '*'), 'b' => fn() => 2, 'c' => fn() => 3];
+$result = array_keys(Helpers::sortBeforeAfter($list));
+Assert::same('a', $result[count($result) - 1], 'a should be last');
+
+
+// Test: Chained dependencies (c before b, b before a)
+$list = ['a' => fn() => 1, 'b' => $order(before: 'a'), 'c' => $order(before: 'b')];
+Assert::same(['c', 'b', 'a'], array_keys(Helpers::sortBeforeAfter($list)));
+
+
+// Test: Missing target ignored
+$list = ['a' => fn() => 1, 'b' => $order(before: 'nonexistent')];
+Assert::same(['a', 'b'], array_keys(Helpers::sortBeforeAfter($list)));
+
+
+// Test: Cycle detection (a before b, b before a)
+Assert::exception(function () use ($order) {
+	$list = ['a' => $order(before: 'b'), 'b' => $order(before: 'a')];
+	Helpers::sortBeforeAfter($list);
+}, LogicException::class);
+
+
+// Test: Multiple before targets
+$list = ['a' => fn() => 1, 'b' => fn() => 2, 'c' => $order(before: ['a', 'b'])];
+Assert::same(['c', 'a', 'b'], array_keys(Helpers::sortBeforeAfter($list)));
+
+
+// Test: Multiple after targets
+$list = ['a' => $order(after: ['b', 'c']), 'b' => fn() => 2, 'c' => fn() => 3];
+Assert::same(['b', 'c', 'a'], array_keys(Helpers::sortBeforeAfter($list)));
+
+
+// Test: Empty list
+Assert::same([], Helpers::sortBeforeAfter([]));
+
+
+// Test: Single item
+$list = ['a' => fn() => 1];
+Assert::same(['a'], array_keys(Helpers::sortBeforeAfter($list)));
+
+
+// Test: Combined before and after on same item
+$list = ['a' => fn() => 1, 'b' => $order(after: 'a', before: 'c'), 'c' => fn() => 3];
+Assert::same(['a', 'b', 'c'], array_keys(Helpers::sortBeforeAfter($list)));
+
+
+// Test: Two items with before: '*' (both want to be first)
+Assert::exception(function () use ($order) {
+	$list = ['a' => $order(before: '*'), 'b' => $order(before: '*')];
+	Helpers::sortBeforeAfter($list);
+}, LogicException::class);
+
+
+// Test: Two items with after: '*' (both want to be last)
+Assert::exception(function () use ($order) {
+	$list = ['a' => $order(after: '*'), 'b' => $order(after: '*')];
+	Helpers::sortBeforeAfter($list);
+}, LogicException::class);

--- a/tests/filters/column.phpt
+++ b/tests/filters/column.phpt
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test: Latte\Essential\Filters::column()
+ */
+
+use Latte\Essential\Filters;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$data = [
+	['id' => 1, 'name' => 'John', 'age' => 30],
+	['id' => 2, 'name' => 'Jane', 'age' => 25],
+	['id' => 3, 'name' => 'Bob', 'age' => 35],
+];
+
+test('extracts single column', function () use ($data) {
+	Assert::same(['John', 'Jane', 'Bob'], Filters::column($data, 'name'));
+	Assert::same([1, 2, 3], Filters::column($data, 'id'));
+	Assert::same([30, 25, 35], Filters::column($data, 'age'));
+});
+
+
+test('extracts column with custom index', function () use ($data) {
+	Assert::same([1 => 'John', 2 => 'Jane', 3 => 'Bob'], Filters::column($data, 'name', 'id'));
+	Assert::same(['John' => 30, 'Jane' => 25, 'Bob' => 35], Filters::column($data, 'age', 'name'));
+});
+
+
+test('extracts all values when column is null', function () use ($data) {
+	Assert::same([
+		['id' => 1, 'name' => 'John', 'age' => 30],
+		['id' => 2, 'name' => 'Jane', 'age' => 25],
+		['id' => 3, 'name' => 'Bob', 'age' => 35],
+	], Filters::column($data, null));
+});
+
+
+test('works with iterable', function () {
+	$iterator = new ArrayIterator([
+		['id' => 1, 'name' => 'Alice'],
+		['id' => 2, 'name' => 'Bob'],
+	]);
+
+	Assert::same(['Alice', 'Bob'], Filters::column($iterator, 'name'));
+});
+
+
+test('works with numeric keys', function () {
+	$data = [
+		[10, 'John', 30],
+		[20, 'Jane', 25],
+		[30, 'Bob', 35],
+	];
+
+	Assert::same(['John', 'Jane', 'Bob'], Filters::column($data, 1));
+	Assert::same([10, 20, 30], Filters::column($data, 0));
+});

--- a/tests/filters/commas.phpt
+++ b/tests/filters/commas.phpt
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test: Latte\Essential\Filters::commas()
+ */
+
+use Latte\Essential\Filters;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('joins array with comma and space by default', function () {
+	Assert::same('one, two, three', Filters::commas(['one', 'two', 'three']));
+	Assert::same('1, 2, 3', Filters::commas(['1', '2', '3']));
+	Assert::same('apple, banana, orange', Filters::commas(['apple', 'banana', 'orange']));
+});
+
+
+test('joins single element', function () {
+	Assert::same('one', Filters::commas(['one']));
+});
+
+
+test('joins empty array', function () {
+	Assert::same('', Filters::commas([]));
+});
+
+
+test('works with numeric values', function () {
+	Assert::same('1, 2, 3', Filters::commas([1, 2, 3]));
+	Assert::same('1.5, 2.5, 3.5', Filters::commas([1.5, 2.5, 3.5]));
+});
+
+
+test('uses custom separator for last pair', function () {
+	Assert::same('one, two and three', Filters::commas(['one', 'two', 'three'], ' and '));
+	Assert::same('one and two', Filters::commas(['one', 'two'], ' and '));
+	Assert::same('apple, banana, or orange', Filters::commas(['apple', 'banana', 'orange'], ', or '));
+	Assert::same('red, green & blue', Filters::commas(['red', 'green', 'blue'], ' & '));
+});
+
+
+test('custom last separator with single element', function () {
+	Assert::same('one', Filters::commas(['one'], ' and '));
+});
+
+
+test('custom last separator with empty array', function () {
+	Assert::same('', Filters::commas([], ' and '));
+});

--- a/tests/filters/slice.phpt
+++ b/tests/filters/slice.phpt
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 /**
- * Test: Latte\Essential\Filters::first()
+ * Test: Latte\Essential\Filters::slice()
  */
 
 use Latte\Essential\Filters;
@@ -37,6 +37,66 @@ test('arrays & preserveKeys', function () {
 	Assert::same([1 => 'b', 10 => 'd', 'e'], Filters::slice($arr, 1, null, true));
 	Assert::same([], Filters::slice($arr, 4, 1, true));
 	Assert::same(['a', 'b'], Filters::slice($arr, 0, -2, true));
+});
+
+
+test('iterators', function () {
+	$gen = function () {
+		yield 'a' => 1;
+		yield 'b' => 2;
+		yield 'c' => 3;
+		yield 'd' => 4;
+		yield 'e' => 5;
+	};
+
+	Assert::type(Generator::class, Filters::slice($gen(), 0));
+	Assert::same([], iterator_to_array(Filters::slice($gen(), 0, 0)));
+	Assert::same([1, 2, 3], iterator_to_array(Filters::slice($gen(), 0, 3)));
+	Assert::same([1, 2, 3, 4, 5], iterator_to_array(Filters::slice($gen(), 0)));
+	Assert::same([1, 2, 3, 4, 5], iterator_to_array(Filters::slice($gen(), 0, 99)));
+	Assert::same([2, 3, 4, 5], iterator_to_array(Filters::slice($gen(), 1)));
+	Assert::same([3, 4, 5], iterator_to_array(Filters::slice($gen(), 2)));
+	Assert::same([3, 4], iterator_to_array(Filters::slice($gen(), 2, 2)));
+	Assert::same([], iterator_to_array(Filters::slice($gen(), 5, 1)));
+});
+
+
+test('iterators & preserveKeys', function () {
+	$gen = function () {
+		yield 'a' => 1;
+		yield 'b' => 2;
+		yield 'c' => 3;
+		yield 'd' => 4;
+		yield 'e' => 5;
+	};
+
+	Assert::same(['a' => 1, 'b' => 2, 'c' => 3], iterator_to_array(Filters::slice($gen(), 0, 3, preserveKeys: true)));
+	Assert::same(['c' => 3, 'd' => 4], iterator_to_array(Filters::slice($gen(), 2, 2, preserveKeys: true)));
+	Assert::same(['b' => 2, 'c' => 3, 'd' => 4, 'e' => 5], iterator_to_array(Filters::slice($gen(), 1, null, preserveKeys: true)));
+});
+
+
+test('limit (slice alias with preserveKeys)', function () {
+	$limit = fn(iterable $value, int $length, int $offset = 0) => Filters::slice($value, $offset, $length, preserveKeys: true);
+
+	$arr = ['a', 'b', 10 => 'd', 'e'];
+
+	Assert::same([0 => 'a', 1 => 'b'], $limit($arr, 2));
+	Assert::same([10 => 'd', 11 => 'e'], $limit($arr, 2, 2));
+	Assert::same($arr, $limit($arr, 99));
+	Assert::same([], $limit($arr, 0));
+
+	$gen = function () {
+		yield 'a' => 1;
+		yield 'b' => 2;
+		yield 'c' => 3;
+		yield 'd' => 4;
+		yield 'e' => 5;
+	};
+
+	Assert::same(['a' => 1, 'b' => 2, 'c' => 3], iterator_to_array($limit($gen(), 3)));
+	Assert::same(['c' => 3, 'd' => 4], iterator_to_array($limit($gen(), 2, 2)));
+	Assert::same([], iterator_to_array($limit($gen(), 0)));
 });
 
 

--- a/tests/tags/expected/foreach.else.php
+++ b/tests/tags/expected/foreach.else.php
@@ -3,6 +3,7 @@
 		foreach ($iterator = $ʟ_it = new Latte\Essential\CachingIterator(['a'], $ʟ_it ?? null) as $item) /* pos 2:1 */ {
 			echo '	item
 ';
+
 		}
 		if ($iterator->isEmpty()) /* pos 4:2 */ {
 			echo '	empty

--- a/tests/tags/expected/foreach.scopedVariables.php
+++ b/tests/tags/expected/foreach.scopedVariables.php
@@ -1,0 +1,18 @@
+<?php
+%A%
+		try {
+			$ʟ_fe_0 = get_defined_vars();
+			unset($v);
+
+			foreach ([1] as $v) /* pos 1:1 */ {
+			}
+
+		} finally {
+			unset($v);
+			if (array_key_exists('v', $ʟ_fe_0)) {
+				$v = &$ʟ_fe_0['v'];
+			}
+
+			unset($ʟ_fe_0);
+		}
+%A%

--- a/tests/tags/foreach.scopedVariables.phpt
+++ b/tests/tags/foreach.scopedVariables.phpt
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test: {foreach} with scoped variables
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+function testScoped(string $title, string $template, string $expected, array $params = [])
+{
+	$latte = createLatte();
+	$latte->setFeature(Latte\Feature::ScopedLoopVariables);
+	Assert::same($expected, $latte->renderToString($template, $params), $title);
+}
+
+
+// Default behavior: variables leak outside the loop (no scoping)
+$latte = createLatte();
+$code = $latte->compile('{foreach [1, 2] as $v}{/foreach}');
+Assert::contains('foreach (', $code);
+Assert::notContains('try {', $code);
+
+
+// With ScopedLoopVariables: generates scope save/restore code
+$latte = createLatte();
+$latte->setFeature(Latte\Feature::ScopedLoopVariables);
+$code = $latte->compile('{foreach [1, 2] as $v}{/foreach}');
+Assert::contains('try {', $code);
+Assert::contains('finally {', $code);
+
+
+testScoped(
+	'variable restored after loop',
+	'{var $v = "X"}before={$v} {foreach [1, 2] as $v}loop={$v} {/foreach}after={$v}',
+	'before=X loop=1 loop=2 after=X',
+);
+
+
+testScoped(
+	'null variable restored after loop',
+	'{var $v = null}before={$v ?? "null"} {foreach [1, 2] as $v}loop={$v} {/foreach}after={$v ?? "null"}{array_key_exists("v", get_defined_vars()) ? " exists" : " !exists"}',
+	'before=null loop=1 loop=2 after=null exists',
+);
+
+
+testScoped(
+	'variable unset after loop (did not exist before)',
+	'{foreach [1, 2] as $v}loop={$v} {/foreach}after={$v ?? "unset"}',
+	'loop=1 loop=2 after=unset',
+);
+
+
+testScoped(
+	'key and value both scoped',
+	'{foreach ["a", "b"] as $k => $v}loop={$k}:{$v} {/foreach}after={$k ?? "unset"}:{$v ?? "unset"}',
+	'loop=0:a loop=1:b after=unset:unset',
+);
+
+
+testScoped(
+	'destructuring: all variables scoped',
+	'{foreach [[1, 2], [3, 4]] as [$a, $b]}loop={$a}-{$b} {/foreach}after={$a ?? "unset"}:{$b ?? "unset"}',
+	'loop=1-2 loop=3-4 after=unset:unset',
+);
+
+
+// Property access ($obj->val): not a simple variable, no scoping
+$latte = createLatte();
+$latte->setFeature(Latte\Feature::ScopedLoopVariables);
+$code = $latte->compile('{var $obj = new stdClass}{foreach [1, 2] as $obj->val}{$obj->val}{/foreach}');
+Assert::notContains('try {', $code);
+
+
+// Reference in foreach ({foreach as &$v}): scoping disabled, would break reference semantics
+$latte = createLatte();
+$latte->setFeature(Latte\Feature::ScopedLoopVariables);
+$code = $latte->compile('{foreach $arr as &$v}{$v}{/foreach}');
+Assert::notContains('try {', $code);
+
+
+// Dynamic variable name ({foreach as ${"'"}}): scoping disabled, only simple names supported
+$latte = createLatte();
+$latte->setFeature(Latte\Feature::ScopedLoopVariables);
+$code = $latte->compile('{foreach [1] as ${"\'"}}{/foreach}');
+Assert::notContains('try {', $code);
+
+
+testScoped(
+	'{else} branch (non-empty)',
+	'{foreach [1, 2] as $v}loop={$v} {else}empty {/foreach}after={$v ?? "unset"}',
+	'loop=1 loop=2 after=unset',
+);
+
+testScoped(
+	'{else} branch (empty)',
+	'{foreach [] as $v}loop={$v} {else}empty {/foreach}after={$v ?? "unset"}',
+	'empty after=unset',
+);
+
+
+// overwrittenVariablesPass: skipped when ScopedLoopVariables enabled (no warning)
+$latte = createLatte();
+$latte->setFeature(Latte\Feature::ScopedLoopVariables);
+Assert::noError(fn() => $latte->renderToString('{foreach [1] as $v}{/foreach}', ['v' => 'param']));
+
+
+testScoped(
+	'empty foreach body',
+	'{var $v = "X"}before={$v} {foreach [1, 2] as $v}{/foreach}after={$v}',
+	'before=X after=X',
+);
+
+
+testScoped(
+	'reference preservation',
+	'{var $v = "X", $ref = &$v}{foreach [1] as $v}{/foreach}v={$v} ref={$ref}',
+	'v=X ref=X',
+);
+
+
+testScoped(
+	'nested loops: independent scopes',
+	'{foreach ["A", "B"] as $v}outer={$v} {foreach ["x", "y"] as $v}inner={$v} {/foreach}restored={$v} {/foreach}after={$v ?? "unset"}',
+	'outer=A inner=x inner=y restored=A outer=B inner=x inner=y restored=B after=unset',
+);
+
+
+// Cleanup: helper array entries are unset after restore
+$latte = createLatte();
+$latte->setFeature(Latte\Feature::ScopedLoopVariables);
+Assert::matchFile(
+	__DIR__ . '/expected/foreach.scopedVariables.php',
+	$latte->compile('{foreach [1] as $v}{/foreach}'),
+);


### PR DESCRIPTION
- bug fix for https://github.com/nette/latte/issues/409
- BC break? don't know

This appears to fix issue 409. However it's not clear to me why the encoding was originally done in the (rather odd) way it was before.