### PR TITLE
Implicit default block for embeds

### DIFF
--- a/src/Latte/Essential/Nodes/EmbedNode.php
+++ b/src/Latte/Essential/Nodes/EmbedNode.php
@@ -8,16 +8,19 @@
 namespace Latte\Essential\Nodes;
 
 use Latte\CompileException;
+use Latte\Compiler\Block;
 use Latte\Compiler\Nodes\FragmentNode;
 use Latte\Compiler\Nodes\Php\Expression\ArrayNode;
 use Latte\Compiler\Nodes\Php\ExpressionNode;
+use Latte\Compiler\Nodes\Php\ModifierNode;
 use Latte\Compiler\Nodes\Php\Scalar\StringNode;
 use Latte\Compiler\Nodes\StatementNode;
 use Latte\Compiler\Nodes\TextNode;
 use Latte\Compiler\PrintContext;
 use Latte\Compiler\Tag;
 use Latte\Compiler\TemplateParser;
-use function count, preg_match;
+use Latte\Compiler\Token;
+use function count, preg_match, trim;
 
 
 /**
@@ -54,10 +57,29 @@ class EmbedNode extends StatementNode
 		$parser->blocks[$parser->blockLayer] = [];
 		[$node->blocks] = yield;
 
+		// Content not wrapped in a {block} becomes the implicit {block default} slot.
+		$kept = $default = [];
 		foreach ($node->blocks->children as $child) {
-			if (!$child instanceof ImportNode && !$child instanceof BlockNode && !$child instanceof TextNode) {
-				throw new CompileException('Unexpected content inside {embed} tags.', $child->position);
+			if ($child instanceof ImportNode || $child instanceof BlockNode) {
+				$kept[] = $child;
+			} elseif ($child instanceof TextNode && trim($child->content) === '') {
+				$kept[] = $child;
+			} else {
+				$default[] = $child;
 			}
+		}
+
+		if ($default) {
+			$blockTag = new Tag('block', [new Token(Token::End, '', $tag->position)], $tag->position, prefix: $tag->prefix);
+			$block = new Block(new StringNode('default'), $node->layer, $blockTag);
+			$parser->checkBlockIsUnique($block);
+			$blockNode = new BlockNode;
+			$blockNode->block = $block;
+			$blockNode->modifier = new ModifierNode([], position: $tag->position);
+			$blockNode->content = new FragmentNode($default);
+			$blockNode->position = $tag->position;
+			$kept[] = $blockNode;
+			$node->blocks->children = $kept;
 		}
 
 		$parser->blockLayer = $prevIndex;

--- a/src/Latte/Essential/Nodes/EmbedNode.php
+++ b/src/Latte/Essential/Nodes/EmbedNode.php
@@ -20,7 +20,7 @@ use Latte\Compiler\PrintContext;
 use Latte\Compiler\Tag;
 use Latte\Compiler\TemplateParser;
 use Latte\Compiler\Token;
-use function count, preg_match, trim;
+use function array_pop, array_shift, count, end, preg_match, trim;
 
 
 /**
@@ -62,11 +62,17 @@ class EmbedNode extends StatementNode
 		foreach ($node->blocks->children as $child) {
 			if ($child instanceof ImportNode || $child instanceof BlockNode) {
 				$kept[] = $child;
-			} elseif ($child instanceof TextNode && trim($child->content) === '') {
-				$kept[] = $child;
 			} else {
 				$default[] = $child;
 			}
+		}
+
+		// ignore whitespace-only text surrounding the blocks, but keep it in between
+		while ($default && $default[0] instanceof TextNode && trim($default[0]->content) === '') {
+			array_shift($default);
+		}
+		while ($default && ($last = end($default)) instanceof TextNode && trim($last->content) === '') {
+			array_pop($default);
 		}
 
 		if ($default) {

--- a/src/Latte/Essential/Nodes/EmbedNode.php
+++ b/src/Latte/Essential/Nodes/EmbedNode.php
@@ -57,7 +57,7 @@ class EmbedNode extends StatementNode
 		$parser->blocks[$parser->blockLayer] = [];
 		[$node->blocks] = yield;
 
-		// Content not wrapped in a {block} becomes the implicit {block default} slot.
+		// Content not wrapped in a {block} becomes the implicit {block default} block.
 		$kept = $default = [];
 		foreach ($node->blocks->children as $child) {
 			if ($child instanceof ImportNode || $child instanceof BlockNode) {
@@ -72,7 +72,7 @@ class EmbedNode extends StatementNode
 		if ($default) {
 			if (isset($parser->blocks[$node->layer]['default'])) {
 				throw new CompileException(
-					'Cannot combine loose content with an explicit {block default} inside {embed}; both define the default slot.',
+					'Cannot combine loose content with an explicit {block default} inside {embed}; both define the default block.',
 					$default[0]->position ?? $tag->position,
 				);
 			}

--- a/src/Latte/Essential/Nodes/EmbedNode.php
+++ b/src/Latte/Essential/Nodes/EmbedNode.php
@@ -70,6 +70,13 @@ class EmbedNode extends StatementNode
 		}
 
 		if ($default) {
+			if (isset($parser->blocks[$node->layer]['default'])) {
+				throw new CompileException(
+					'Cannot combine loose content with an explicit {block default} inside {embed}; both define the default slot.',
+					$default[0]->position ?? $tag->position,
+				);
+			}
+
 			$blockTag = new Tag('block', [new Token(Token::End, '', $tag->position)], $tag->position, prefix: $tag->prefix);
 			$block = new Block(new StringNode('default'), $node->layer, $blockTag);
 			$parser->checkBlockIsUnique($block);

--- a/tests/tags/embed.block.phpt
+++ b/tests/tags/embed.block.phpt
@@ -425,13 +425,13 @@ testTemplate(
 
 
 testTemplate(
-	'default block: override, fallback, and named blocks',
+	'default block: works together with named blocks',
 	[
 		'main' => <<<'XX'
 
 					{embed embed}DEFAULT-OVER{block title}TITLE-OVER{/block}{/embed}
 
-					{define embed}title={block title}TITLE-FB{/block} body=[{block default}DEFAULT-FB{/block}]{/define}
+					{define embed}title={block title}fallback{/block} body=[{block default}fallback{/block}]{/define}
 
 			XX,
 	],
@@ -444,52 +444,52 @@ testTemplate(
 
 
 testTemplate(
-	'default block: fallback used when caller is self-closing',
+	'default block: self-closing caller keeps the fallback',
 	[
 		'main' => <<<'XX'
 
 					{embed embed/}
 
-					{define embed}body=[{block default}DEFAULT{/block}]{/define}
+					{define embed}body=[{block default}fallback{/block}]{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[DEFAULT]
+			body=[fallback]
 
 		XX,
 );
 
 
 testTemplate(
-	'default block: fallback used when caller is empty',
+	'default block: empty caller keeps the fallback',
 	[
 		'main' => <<<'XX'
 
 					{embed embed}{/embed}
 
-					{define embed}body=[{block default}DEFAULT{/block}]{/define}
+					{define embed}body=[{block default}fallback{/block}]{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[DEFAULT]
+			body=[fallback]
 
 		XX,
 );
 
 
 testTemplate(
-	'default block: arbitrary sub-nodes and caller variables',
+	'default block: default content sees caller variables',
 	[
 		'main' => <<<'XX'
 
 					{var $outer = 'OUT'}
 					{embed embed}{var $local = 'LOC'}{$outer}-{$local}{if true}!{/if}{/embed}
 
-					{define embed}body=[{block default}DEFAULT-FB{/block}]{/define}
+					{define embed}body=[{block default}fallback{/block}]{/define}
 
 			XX,
 	],

--- a/tests/tags/embed.block.phpt
+++ b/tests/tags/embed.block.phpt
@@ -424,6 +424,83 @@ testTemplate(
 );
 
 
+testTemplate(
+	'default block: override, fallback, and named blocks',
+	[
+		'main' => <<<'XX'
+
+					{embed embed}DEFAULT-OVER{block title}TITLE-OVER{/block}{/embed}
+
+					{define embed}title={block title}TITLE-FB{/block} body=[{block default}DEFAULT-FB{/block}]{/define}
+
+			XX,
+	],
+	<<<'XX'
+
+			title=TITLE-OVER body=[DEFAULT-OVER]
+
+		XX,
+);
+
+
+testTemplate(
+	'default block: fallback used when caller is self-closing',
+	[
+		'main' => <<<'XX'
+
+					{embed embed/}
+
+					{define embed}body=[{block default}DEFAULT{/block}]{/define}
+
+			XX,
+	],
+	<<<'XX'
+
+			body=[DEFAULT]
+
+		XX,
+);
+
+
+testTemplate(
+	'default block: fallback used when caller is empty',
+	[
+		'main' => <<<'XX'
+
+					{embed embed}{/embed}
+
+					{define embed}body=[{block default}DEFAULT{/block}]{/define}
+
+			XX,
+	],
+	<<<'XX'
+
+			body=[DEFAULT]
+
+		XX,
+);
+
+
+testTemplate(
+	'default block: arbitrary sub-nodes and caller variables',
+	[
+		'main' => <<<'XX'
+
+					{var $outer = 'OUT'}
+					{embed embed}{var $local = 'LOC'}{$outer}-{$local}{if true}!{/if}{/embed}
+
+					{define embed}body=[{block default}DEFAULT-FB{/block}]{/define}
+
+			XX,
+	],
+	<<<'XX'
+
+			body=[OUT-LOC!]
+
+		XX,
+);
+
+
 $latte = createLatte();
 Assert::exception(
 	fn() => $latte->renderToString('{embed block (null)/}'),

--- a/tests/tags/embed.block.phpt
+++ b/tests/tags/embed.block.phpt
@@ -431,13 +431,13 @@ testTemplate(
 
 					{embed embed}custom body{block title}custom title{/block}{/embed}
 
-					{define embed}title={block title}fallback title{/block} body=[{block default}fallback body{/block}]{/define}
+					{define embed}title={block title}fallback title{/block} body={block default}fallback body{/block}{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			title=custom title body=[custom body]
+			title=custom title body=custom body
 
 		XX,
 );
@@ -450,13 +450,13 @@ testTemplate(
 
 					{embed embed/}
 
-					{define embed}body=[{block default}fallback body{/block}]{/define}
+					{define embed}body={block default}fallback body{/block}{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[fallback body]
+			body=fallback body
 
 		XX,
 );
@@ -469,13 +469,13 @@ testTemplate(
 
 					{embed embed}{/embed}
 
-					{define embed}body=[{block default}fallback body{/block}]{/define}
+					{define embed}body={block default}fallback body{/block}{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[fallback body]
+			body=fallback body
 
 		XX,
 );
@@ -489,13 +489,13 @@ testTemplate(
 					{var $greeting = 'Hello'}
 					{embed embed}{var $name = 'world'}{$greeting} {$name}{if true}!{/if}{/embed}
 
-					{define embed}body=[{block default}fallback body{/block}]{/define}
+					{define embed}body={block default}fallback body{/block}{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[Hello world!]
+			body=Hello world!
 
 		XX,
 );

--- a/tests/tags/embed.block.phpt
+++ b/tests/tags/embed.block.phpt
@@ -429,15 +429,15 @@ testTemplate(
 	[
 		'main' => <<<'XX'
 
-					{embed embed}DEFAULT-OVER{block title}TITLE-OVER{/block}{/embed}
+					{embed embed}custom body{block title}custom title{/block}{/embed}
 
-					{define embed}title={block title}fallback{/block} body=[{block default}fallback{/block}]{/define}
+					{define embed}title={block title}fallback title{/block} body=[{block default}fallback body{/block}]{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			title=TITLE-OVER body=[DEFAULT-OVER]
+			title=custom title body=[custom body]
 
 		XX,
 );
@@ -450,13 +450,13 @@ testTemplate(
 
 					{embed embed/}
 
-					{define embed}body=[{block default}fallback{/block}]{/define}
+					{define embed}body=[{block default}fallback body{/block}]{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[fallback]
+			body=[fallback body]
 
 		XX,
 );
@@ -469,13 +469,13 @@ testTemplate(
 
 					{embed embed}{/embed}
 
-					{define embed}body=[{block default}fallback{/block}]{/define}
+					{define embed}body=[{block default}fallback body{/block}]{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[fallback]
+			body=[fallback body]
 
 		XX,
 );
@@ -486,16 +486,16 @@ testTemplate(
 	[
 		'main' => <<<'XX'
 
-					{var $outer = 'OUT'}
-					{embed embed}{var $local = 'LOC'}{$outer}-{$local}{if true}!{/if}{/embed}
+					{var $greeting = 'Hello'}
+					{embed embed}{var $name = 'world'}{$greeting} {$name}{if true}!{/if}{/embed}
 
-					{define embed}body=[{block default}fallback{/block}]{/define}
+					{define embed}body=[{block default}fallback body{/block}]{/define}
 
 			XX,
 	],
 	<<<'XX'
 
-			body=[OUT-LOC!]
+			body=[Hello world!]
 
 		XX,
 );

--- a/tests/tags/embed.file.phpt
+++ b/tests/tags/embed.file.phpt
@@ -920,13 +920,13 @@ testTemplate(
 			XX,
 		'embed.latte' => <<<'XX'
 			start
-			[{block default}fallback body{/block}]
+			{block default}fallback body{/block}
 			end
 			XX,
 	],
 	<<<'XX'
 		start
-		[custom body]
+		custom body
 		end
 		XX,
 );
@@ -940,13 +940,13 @@ testTemplate(
 			XX,
 		'embed.latte' => <<<'XX'
 			start
-			[{block default}fallback body{/block}]
+			{block default}fallback body{/block}
 			end
 			XX,
 	],
 	<<<'XX'
 		start
-		[fallback body]
+		fallback body
 		end
 		XX,
 );
@@ -960,13 +960,13 @@ testTemplate(
 			XX,
 		'embed.latte' => <<<'XX'
 			start
-			[{block default}fallback body{/block}]
+			{block default}fallback body{/block}
 			end
 			XX,
 	],
 	<<<'XX'
 		start
-		[fallback body]
+		fallback body
 		end
 		XX,
 );
@@ -980,13 +980,13 @@ testTemplate(
 			XX,
 		'embed.latte' => <<<'XX'
 			start
-			[{block default}fallback body{/block}]
+			{block default}fallback body{/block}
 			end
 			XX,
 	],
 	<<<'XX'
 		start
-		[fallback body]
+		fallback body
 		end
 		XX,
 );
@@ -1000,13 +1000,13 @@ testTemplate(
 			XX,
 		'embed.latte' => <<<'XX'
 			start
-			[{block default}fallback body{/block}]
+			{block default}fallback body{/block}
 			end
 			XX,
 	],
 	<<<'XX'
 		start
-		[Hello world!]
+		Hello world!
 		end
 		XX,
 );
@@ -1020,12 +1020,12 @@ testTemplate(
 			XX,
 		'embed.latte' => <<<'XX'
 			title={block title}fallback title{/block}
-			body=[{block default}fallback body{/block}]
+			body={block default}fallback body{/block}
 			XX,
 	],
 	<<<'XX'
 		title=custom title
-		body=[custom body]
+		body=custom body
 		XX,
 );
 

--- a/tests/tags/embed.file.phpt
+++ b/tests/tags/embed.file.phpt
@@ -18,10 +18,11 @@ function testTemplate(string $title, array $templates, string $exp = '')
 
 
 Assert::exception(function () {
-	testTemplate('unexpected content', [
-		'main' => '{embed "embed.latte"} {$a} {/embed}',
+	testTemplate('default block: loose content mixed with explicit block', [
+		'main' => '{embed "embed.latte"}loose{block default}explicit{/block}{/embed}',
+		'embed.latte' => '[{block default}x{/block}]',
 	]);
-}, Latte\CompileException::class, 'Unexpected content inside {embed} tags (on line 1 at column 23)');
+}, Latte\CompileException::class, 'Cannot combine loose content with an explicit {block default} inside {embed}; both define the default block (on line 1 at column 22)');
 
 
 testTemplate('keyword file', [

--- a/tests/tags/embed.file.phpt
+++ b/tests/tags/embed.file.phpt
@@ -913,52 +913,52 @@ testTemplate(
 
 
 testTemplate('default block: caller content overrides the fallback', [
-	'main' => '{embed "embed.latte"}OVERRIDE{/embed}',
-	'embed.latte' => 'start [{block default}fallback{/block}] end',
-], 'start [OVERRIDE] end');
+	'main' => '{embed "embed.latte"}custom body{/embed}',
+	'embed.latte' => 'start [{block default}fallback body{/block}] end',
+], 'start [custom body] end');
 
 
 testTemplate('default block: empty caller keeps the fallback', [
 	'main' => '{embed "embed.latte"}{/embed}',
-	'embed.latte' => 'start [{block default}fallback{/block}] end',
-], 'start [fallback] end');
+	'embed.latte' => 'start [{block default}fallback body{/block}] end',
+], 'start [fallback body] end');
 
 
 testTemplate('default block: self-closing caller keeps the fallback', [
 	'main' => '{embed "embed.latte"/}',
-	'embed.latte' => 'start [{block default}fallback{/block}] end',
-], 'start [fallback] end');
+	'embed.latte' => 'start [{block default}fallback body{/block}] end',
+], 'start [fallback body] end');
 
 
 testTemplate('default block: whitespace-only caller keeps the fallback', [
 	'main' => '{embed "embed.latte"}   {/embed}',
-	'embed.latte' => 'start [{block default}fallback{/block}] end',
-], 'start [fallback] end');
+	'embed.latte' => 'start [{block default}fallback body{/block}] end',
+], 'start [fallback body] end');
 
 
 testTemplate('default block: default content sees caller variables', [
 	'main' => <<<'XX'
-		{var $outer = 'OUT'}{embed "embed.latte"}{var $local = 'LOC'}{$outer}-{$local}{if true}!{/if}{/embed}
+		{var $greeting = 'Hello'}{embed "embed.latte"}{var $name = 'world'}{$greeting} {$name}{if true}!{/if}{/embed}
 		XX,
-	'embed.latte' => 'start [{block default}fallback{/block}] end',
-], 'start [OUT-LOC!] end');
+	'embed.latte' => 'start [{block default}fallback body{/block}] end',
+], 'start [Hello world!] end');
 
 
 testTemplate('default block: works together with named blocks', [
-	'main' => '{embed "embed.latte"}DEFAULT-OVER{block title}TITLE-OVER{/block}{/embed}',
-	'embed.latte' => 'title={block title}fallback{/block} body=[{block default}fallback{/block}]',
-], 'title=TITLE-OVER body=[DEFAULT-OVER]');
+	'main' => '{embed "embed.latte"}custom body{block title}custom title{/block}{/embed}',
+	'embed.latte' => 'title={block title}fallback title{/block} body=[{block default}fallback body{/block}]',
+], 'title=custom title body=[custom body]');
 
 
 testTemplate('default block: caller content ignored without a placeholder', [
-	'main' => '{embed "embed.latte"}{var $x = 1}{$x} ignored{/embed}',
+	'main' => '{embed "embed.latte"}custom body{/embed}',
 	'embed.latte' => 'no placeholder here',
 ], 'no placeholder here');
 
 
 Assert::exception(function () {
 	testTemplate('default block: loose content mixed with explicit block', [
-		'main' => '{embed "embed.latte"}loose{block default}explicit{/block}{/embed}',
+		'main' => '{embed "embed.latte"}custom body{block default}explicit body{/block}{/embed}',
 		'embed.latte' => '[{block default}x{/block}]',
 	]);
 }, Latte\CompileException::class, 'Cannot combine loose content with an explicit {block default} inside {embed}; both define the default block (on line 1 at column 22)');

--- a/tests/tags/embed.file.phpt
+++ b/tests/tags/embed.file.phpt
@@ -914,44 +914,46 @@ testTemplate(
 
 testTemplate('default block: caller content overrides the fallback', [
 	'main' => '{embed "embed.latte"}OVERRIDE{/embed}',
-	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
+	'embed.latte' => 'start [{block default}fallback{/block}] end',
 ], 'start [OVERRIDE] end');
 
 
-testTemplate('default block: fallback used when caller is self-closing', [
-	'main' => '{embed "embed.latte"/}',
-	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
-], 'start [FALLBACK] end');
-
-
-testTemplate('default block: fallback used when caller is empty', [
+testTemplate('default block: empty caller keeps the fallback', [
 	'main' => '{embed "embed.latte"}{/embed}',
-	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
-], 'start [FALLBACK] end');
+	'embed.latte' => 'start [{block default}fallback{/block}] end',
+], 'start [fallback] end');
 
 
-testTemplate('default block: whitespace-only content keeps the fallback', [
+testTemplate('default block: self-closing caller keeps the fallback', [
+	'main' => '{embed "embed.latte"/}',
+	'embed.latte' => 'start [{block default}fallback{/block}] end',
+], 'start [fallback] end');
+
+
+testTemplate('default block: whitespace-only caller keeps the fallback', [
 	'main' => '{embed "embed.latte"}   {/embed}',
-	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
-], 'start [FALLBACK] end');
+	'embed.latte' => 'start [{block default}fallback{/block}] end',
+], 'start [fallback] end');
 
 
-testTemplate('default block: arbitrary sub-nodes and caller variables', [
-	'main' => "{var \$outer = 'OUT'}{embed \"embed.latte\"}{var \$local = 'LOC'}{\$outer}-{\$local}{if true}!{/if}{/embed}",
-	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
+testTemplate('default block: default content sees caller variables', [
+	'main' => <<<'XX'
+		{var $outer = 'OUT'}{embed "embed.latte"}{var $local = 'LOC'}{$outer}-{$local}{if true}!{/if}{/embed}
+		XX,
+	'embed.latte' => 'start [{block default}fallback{/block}] end',
 ], 'start [OUT-LOC!] end');
 
 
-testTemplate('default block: coexists with named blocks', [
+testTemplate('default block: works together with named blocks', [
 	'main' => '{embed "embed.latte"}DEFAULT-OVER{block title}TITLE-OVER{/block}{/embed}',
-	'embed.latte' => 'title={block title}TITLE-FB{/block} body=[{block default}DEFAULT-FB{/block}]',
+	'embed.latte' => 'title={block title}fallback{/block} body=[{block default}fallback{/block}]',
 ], 'title=TITLE-OVER body=[DEFAULT-OVER]');
 
 
 testTemplate('default block: caller content ignored without a placeholder', [
 	'main' => '{embed "embed.latte"}{var $x = 1}{$x} ignored{/embed}',
-	'embed.latte' => 'no block here',
-], 'no block here');
+	'embed.latte' => 'no placeholder here',
+], 'no placeholder here');
 
 
 Assert::exception(function () {

--- a/tests/tags/embed.file.phpt
+++ b/tests/tags/embed.file.phpt
@@ -912,48 +912,134 @@ testTemplate(
 );
 
 
-testTemplate('default block: caller content overrides the fallback', [
-	'main' => '{embed "embed.latte"}custom body{/embed}',
-	'embed.latte' => 'start [{block default}fallback body{/block}] end',
-], 'start [custom body] end');
-
-
-testTemplate('default block: empty caller keeps the fallback', [
-	'main' => '{embed "embed.latte"}{/embed}',
-	'embed.latte' => 'start [{block default}fallback body{/block}] end',
-], 'start [fallback body] end');
-
-
-testTemplate('default block: self-closing caller keeps the fallback', [
-	'main' => '{embed "embed.latte"/}',
-	'embed.latte' => 'start [{block default}fallback body{/block}] end',
-], 'start [fallback body] end');
-
-
-testTemplate('default block: whitespace-only caller keeps the fallback', [
-	'main' => '{embed "embed.latte"}   {/embed}',
-	'embed.latte' => 'start [{block default}fallback body{/block}] end',
-], 'start [fallback body] end');
-
-
-testTemplate('default block: default content sees caller variables', [
-	'main' => <<<'XX'
-		{var $greeting = 'Hello'}{embed "embed.latte"}{var $name = 'world'}{$greeting} {$name}{if true}!{/if}{/embed}
+testTemplate(
+	'default block: caller content overrides the fallback',
+	[
+		'main' => <<<'XX'
+			{embed "embed.latte"}custom body{/embed}
+			XX,
+		'embed.latte' => <<<'XX'
+			start
+			[{block default}fallback body{/block}]
+			end
+			XX,
+	],
+	<<<'XX'
+		start
+		[custom body]
+		end
 		XX,
-	'embed.latte' => 'start [{block default}fallback body{/block}] end',
-], 'start [Hello world!] end');
+);
 
 
-testTemplate('default block: works together with named blocks', [
-	'main' => '{embed "embed.latte"}custom body{block title}custom title{/block}{/embed}',
-	'embed.latte' => 'title={block title}fallback title{/block} body=[{block default}fallback body{/block}]',
-], 'title=custom title body=[custom body]');
+testTemplate(
+	'default block: empty caller keeps the fallback',
+	[
+		'main' => <<<'XX'
+			{embed "embed.latte"}{/embed}
+			XX,
+		'embed.latte' => <<<'XX'
+			start
+			[{block default}fallback body{/block}]
+			end
+			XX,
+	],
+	<<<'XX'
+		start
+		[fallback body]
+		end
+		XX,
+);
 
 
-testTemplate('default block: caller content ignored without a placeholder', [
-	'main' => '{embed "embed.latte"}custom body{/embed}',
-	'embed.latte' => 'no placeholder here',
-], 'no placeholder here');
+testTemplate(
+	'default block: self-closing caller keeps the fallback',
+	[
+		'main' => <<<'XX'
+			{embed "embed.latte"/}
+			XX,
+		'embed.latte' => <<<'XX'
+			start
+			[{block default}fallback body{/block}]
+			end
+			XX,
+	],
+	<<<'XX'
+		start
+		[fallback body]
+		end
+		XX,
+);
+
+
+testTemplate(
+	'default block: whitespace-only caller keeps the fallback',
+	[
+		'main' => <<<'XX'
+			{embed "embed.latte"}   {/embed}
+			XX,
+		'embed.latte' => <<<'XX'
+			start
+			[{block default}fallback body{/block}]
+			end
+			XX,
+	],
+	<<<'XX'
+		start
+		[fallback body]
+		end
+		XX,
+);
+
+
+testTemplate(
+	'default block: default content sees caller variables',
+	[
+		'main' => <<<'XX'
+			{var $greeting = 'Hello'}{embed "embed.latte"}{var $name = 'world'}{$greeting} {$name}{if true}!{/if}{/embed}
+			XX,
+		'embed.latte' => <<<'XX'
+			start
+			[{block default}fallback body{/block}]
+			end
+			XX,
+	],
+	<<<'XX'
+		start
+		[Hello world!]
+		end
+		XX,
+);
+
+
+testTemplate(
+	'default block: works together with named blocks',
+	[
+		'main' => <<<'XX'
+			{embed "embed.latte"}custom body{block title}custom title{/block}{/embed}
+			XX,
+		'embed.latte' => <<<'XX'
+			title={block title}fallback title{/block}
+			body=[{block default}fallback body{/block}]
+			XX,
+	],
+	<<<'XX'
+		title=custom title
+		body=[custom body]
+		XX,
+);
+
+
+testTemplate(
+	'default block: caller content ignored without a placeholder',
+	[
+		'main' => <<<'XX'
+			{embed "embed.latte"}custom body{/embed}
+			XX,
+		'embed.latte' => 'no placeholder here',
+	],
+	'no placeholder here',
+);
 
 
 Assert::exception(function () {

--- a/tests/tags/embed.file.phpt
+++ b/tests/tags/embed.file.phpt
@@ -912,6 +912,56 @@ testTemplate(
 );
 
 
+testTemplate('default block: caller content overrides the fallback', [
+	'main' => '{embed "embed.latte"}OVERRIDE{/embed}',
+	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
+], 'start [OVERRIDE] end');
+
+
+testTemplate('default block: fallback used when caller is self-closing', [
+	'main' => '{embed "embed.latte"/}',
+	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
+], 'start [FALLBACK] end');
+
+
+testTemplate('default block: fallback used when caller is empty', [
+	'main' => '{embed "embed.latte"}{/embed}',
+	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
+], 'start [FALLBACK] end');
+
+
+testTemplate('default block: whitespace-only content keeps the fallback', [
+	'main' => '{embed "embed.latte"}   {/embed}',
+	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
+], 'start [FALLBACK] end');
+
+
+testTemplate('default block: arbitrary sub-nodes and caller variables', [
+	'main' => "{var \$outer = 'OUT'}{embed \"embed.latte\"}{var \$local = 'LOC'}{\$outer}-{\$local}{if true}!{/if}{/embed}",
+	'embed.latte' => 'start [{block default}FALLBACK{/block}] end',
+], 'start [OUT-LOC!] end');
+
+
+testTemplate('default block: coexists with named blocks', [
+	'main' => '{embed "embed.latte"}DEFAULT-OVER{block title}TITLE-OVER{/block}{/embed}',
+	'embed.latte' => 'title={block title}TITLE-FB{/block} body=[{block default}DEFAULT-FB{/block}]',
+], 'title=TITLE-OVER body=[DEFAULT-OVER]');
+
+
+testTemplate('default block: caller content ignored without a placeholder', [
+	'main' => '{embed "embed.latte"}{var $x = 1}{$x} ignored{/embed}',
+	'embed.latte' => 'no block here',
+], 'no block here');
+
+
+Assert::exception(function () {
+	testTemplate('default block: loose content mixed with explicit block', [
+		'main' => '{embed "embed.latte"}loose{block default}explicit{/block}{/embed}',
+		'embed.latte' => '[{block default}x{/block}]',
+	]);
+}, Latte\CompileException::class, 'Cannot combine loose content with an explicit {block default} inside {embed}; both define the default block (on line 1 at column 22)');
+
+
 $latte = createLatte();
 Assert::exception(
 	fn() => $latte->renderToString('{embed (null)/}'),

--- a/tests/tags/embed.file.phpt
+++ b/tests/tags/embed.file.phpt
@@ -17,14 +17,6 @@ function testTemplate(string $title, array $templates, string $exp = '')
 }
 
 
-Assert::exception(function () {
-	testTemplate('default block: loose content mixed with explicit block', [
-		'main' => '{embed "embed.latte"}loose{block default}explicit{/block}{/embed}',
-		'embed.latte' => '[{block default}x{/block}]',
-	]);
-}, Latte\CompileException::class, 'Cannot combine loose content with an explicit {block default} inside {embed}; both define the default block (on line 1 at column 22)');
-
-
 testTemplate('keyword file', [
 	'main' => '{embed file embed}{/embed}',
 	'embed' => 'embed',


### PR DESCRIPTION
- New feature, closes #417
- BC break? no
- doc PR: happy to write one if you're on board with this feature :)

## What this does

Provide an implicit `default` block for `embed`s and move any "loose" children into that default block.

Mirrors how other templating libraries deal with default/unnamed slots.

```latte
{* Pass button label into implicit `default` block *}

{embed button}
  Submit
{/embed}
```

## Current state

Currently, I manually have to define the default block when embedding.

```latte
{define button}
  <button>
    {block default}Click{/block}
  </button>
{/define}

{embed button}
  {block default}
    Submit
  {/block}
{/embed}
```

It's a lot of noise when using many embeds.

```latte
<ul>
  <li>{embed button} {block default} Submit {/block} {/embed}</li>
  <li>{embed button} {block default} Reset {/block} {/embed}</li>
  <li>{embed button} {block default} Cancel {/block} {/embed}</li>
</ul>
```

## With this feature

This will move any "loose" children into an implicit `default` block that the template file can render as necessary. 

```diff
 {embed button}
-   {block default}
     Submit
-   {/block}
{/embed}
```

```latte
<ul>
  <li>{embed button}Submit{/embed}</li>
  <li>{embed button}Reset{/embed}</li>
  <li>{embed button}Cancel{/embed}</li>
</ul>
```

Explicit blocks and the implicit default block can live side by side.

```latte
{define button}
  <button>
    {block default}Click{/block}
    {block icon}<svg />{/block}
  </button>
{/define}

{embed button}
  Submit
  {block icon}<svg />{/block}
{/embed}
```

Explicit and implicit `default` block can never coexist and end up with a new compile error.

```latte
{* Throws: "Cannot combine loose content with an explicit {block default} inside {embed}"  *}

{embed button}
  Submit
  {block default}Send{/block}
{/embed}
```

## Tests

Tests are added.

## Nonbreaking

No existing tests have been modified.

Templates currently using a `default` block will keep working.

Also, this does not automatically render the loose content. Loose content is still ignored, just as before. It requires defining a `{block default}` inside the embedded content.

## Alternative implementation

I was thinking of using an unnamed block instead of a default block. Not sure if that would've worked even? Also, I think `default` reads more intentional and in line with how most templating engines name their default slots.

```latte
{define button}
  <button>
    {block}Click{/block}
    {block icon}<svg />{/block}
  </button>
{/define}
```